### PR TITLE
Fixed embed bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Scratch/bin/Debug/net7.0/Scratch.dll",
+            "program": "${workspaceFolder}/artifacts/bin/Scratch/Debug/Scratch.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Scratch",
             "console": "internalConsole",

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -312,7 +312,7 @@ public sealed class ExportUtilTests : TestBase
     }
 
     [Fact]
-    public void ExportRsp()
+    public void ExportRsp1()
     {
         var args = new[]
         {
@@ -337,4 +337,21 @@ public sealed class ExportUtilTests : TestBase
         Assert.Equal(@"""blah .cs"" /r:blah .cs ""a b.cs"" ab.cs", writer.ToString()); 
     }
 
+    [Fact]
+    public void ExportRsp2()
+    {
+        var args = new[]
+        {
+            "blah.cs",
+            @"/embed:""c:\blah\a,b=net472.cs""",
+        };
+
+        using var writer = new StringWriter();
+        ExportUtil.ExportRsp(args, writer);
+        Assert.Equal("""
+            blah.cs
+            /embed:"c:\blah\a,b=net472.cs"
+
+            """, writer.ToString());
+    }
 }

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -407,13 +407,12 @@ public sealed class ExportUtil
 
     private static string MaybeQuoteArgument(string arg)
     {
-        if (arg.Contains(' ') && !IsOption(arg.AsSpan()))
+        if (IsOption(arg.AsSpan()))
         {
-            var str = $@"""{arg}""";
-            return str;
+            return arg;
         }
 
-        if (arg.Contains('=') || arg.Contains(','))
+        if (arg.Contains(' ') || arg.Contains('=') || arg.Contains(','))
         {
             var str = $@"""{arg}""";
             return str;

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -15,7 +15,8 @@ using TraceReloggerLib;
 #pragma warning disable 8321
 
 //  var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
-var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.complog";
+// var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.complog";
+var filePath = @"C:\Users\jaredpar\code\vs-threading\msbuild.binlog";
 // var filePath = @"c:\users\jaredpar\temp\Build.complog";
 // var filePath = @"C:\Users\jaredpar\code\MudBlazor\src\msbuild.binlog";
 // var filePath = @"C:\Users\jaredpar\code\roslyn\src\Compilers\Core\Portable\msbuild.binlog";
@@ -32,9 +33,9 @@ var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.complog
 
 // Profile();
 
-var timeSpan = DateTime.UtcNow;
-RunComplog($"replay {filePath}");
-Console.WriteLine(DateTime.UtcNow - timeSpan);
+// var timeSpan = DateTime.UtcNow;
+RunComplog($"rsp {filePath} --project Microsoft.VisualStudio.Threading.Tests");
+// Console.WriteLine(DateTime.UtcNow - timeSpan);
 
 /*
 using var reader = CompilerLogReader.Create(filePath);


### PR DESCRIPTION
The .NET SDK produces a file name with = and , characters inside it on every build. Example:

> net472\.NETFramework,Version=v4.7.2.AssemblyAttributes.cs

This file will be quoted when passed as an argument to say `/embed` and the existing logic was causing the entire option to be quoted.