### PR TITLE
Fixed testing issue

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -79,38 +79,4 @@ public sealed class UsingAllCompilerLogTests : TestBase
             Assert.NotEmpty(solution.Projects);
         }
     }
-
-    /// <summary>
-    /// Ensure that our options round tripping code is correct and produces the same result as 
-    /// argument parsing. This will also catch cases where new values are added to the options 
-    /// that are not being set by our code base.
-    /// </summary>
-    [Fact]
-    public async Task OptionsCorrectness()
-    {
-        await foreach (var complogPath in Fixture.GetAllCompilerLogs(TestOutputHelper))
-        {
-            TestOutputHelper.WriteLine(complogPath);
-            using var reader = CompilerLogReader.Create(complogPath);
-            foreach (var data in reader.ReadAllCompilationData())
-            {
-                var args = data.CompilerCall.ParseArguments();
-                Assert.Equal(args.EmitOptions, data.EmitOptions);
-                Assert.Equal(args.ParseOptions, data.ParseOptions);
-
-                // TODO: can't round trip ruleset options yet because it isn't 
-                // handled in specific diagnostic potions
-                if (complogPath != Fixture.ConsoleComplexComplogPath.Value)
-                {
-                    var expectedCompilationOptions = args.CompilationOptions
-                        .WithCryptoKeyFile(null);
-                    var actualCompilationOptions = data.CompilationOptions
-                        .WithSyntaxTreeOptionsProvider(null)
-                        .WithStrongNameProvider(null)
-                        .WithCryptoKeyFile(null);
-                    Assert.Equal(expectedCompilationOptions, actualCompilationOptions);
-                }
-            }
-        }
-    }
 }

--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -74,7 +74,7 @@ internal sealed class CompilerLogBuilder : IDisposable
                 IsCSharp = compilerCall.IsCSharp,
                 TargetFramework = compilerCall.TargetFramework,
                 CompilerCallKind = compilerCall.Kind,
-                CommandLineArgsHash = AddContentMessagePack(compilerCall.Arguments),
+                CommandLineArgsHash = AddContentMessagePack(compilerCall.GetArguments()),
                 CompilationDataPackHash = AddCompilationDataPack(commandLineArguments),
             };
 

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -198,7 +198,7 @@ public sealed class ExportUtil
             // compiler options aren't case sensitive
             var comparison = StringComparison.OrdinalIgnoreCase;
 
-            foreach (var line in compilerCall.Arguments)
+            foreach (var line in compilerCall.GetArguments())
             {
                 // The only non-options are source files and those are rewritten by other 
                 // methods and added to commandLineList
@@ -380,7 +380,7 @@ public sealed class ExportUtil
     }
 
     public static void ExportRsp(CompilerCall compilerCall, TextWriter writer, bool singleLine = false) =>
-        ExportRsp(compilerCall.Arguments, writer, singleLine);
+        ExportRsp(compilerCall.GetArguments(), writer, singleLine);
 
     public static void ExportRsp(IEnumerable<string> arguments, TextWriter writer, bool singleLine = false)
     {


### PR DESCRIPTION
The options testing was using `CommandLineArguments.Parse` after content was deleted off of disk. That fails for certain operations like when a ruleset file is used. To fix this just moved the option round trip testing to the point of creation of the compiler log and that fixed the issue.