### PR TITLE
Fix bug with separate state

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -184,6 +184,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                     <Win32Manifest>resource.txt</Win32Manifest>
                     <KeyOriginatorFile>{keyFilePath}</KeyOriginatorFile>
                     <DocumentationFile>console-complex.xml</DocumentationFile>
+                    <SourceLink>example.sourcelink</SourceLink>
                   </PropertyGroup>
                   <ItemGroup>
                     <EmbeddedResource Include="resource.txt" />
@@ -237,6 +238,14 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                         <Rule Id="CA2217" Action="Warning" />
                     </Rules>
                 </RuleSet>
+                """);
+
+            File.WriteAllText(Path.Combine(scratchPath, "example.sourcelink"), """
+                {
+                    "documents": {
+                        "C:\\src\\complog\\*": "https://raw.githubusercontent.com/dotnet/complog/bcc51178e1a82fb2edaf47285f6e577989a7333f/*"
+                    }
+                }
                 """);
             RunDotnetCommand("build -bl -nr:false", scratchPath);
         });

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -298,6 +298,24 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.Equal(BasicAnalyzerHostNone.CannotReadGeneratedFiles.Id, diagnostics[0].Id);
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(100)]
+    public void ReadCompilerCallBadIndex(int index)
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value);
+        Assert.Throws<ArgumentException>(() => reader.ReadCompilerCall(index));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(100)]
+    public void ReadCompilationDataBadIndex(int index)
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value);
+        Assert.Throws<ArgumentException>(() => reader.ReadCompilationData(index));
+    }
+
     [Fact]
     public void KindWpf()
     {

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -60,7 +60,7 @@ public sealed class CompilerLogReaderTests : TestBase
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplexComplogPath.Value);
         var rawData = reader.ReadRawCompilationData(0).Item2;
         var d = rawData.Resources.Single();
-        Assert.Equal("console-complex.resource.txt", d.ResourceDescription.GetResourceName());
+        Assert.Equal("console-complex.resource.txt", reader.ReadResourceDescription(d).GetResourceName());
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/TempDir.cs
+++ b/src/Basic.CompilerLog.UnitTests/TempDir.cs
@@ -36,8 +36,9 @@ internal sealed class TempDir : IDisposable
         return filePath;
     }
 
-    public string NewDirectory(string name)
+    public string NewDirectory(string? name = null)
     {
+        name ??= Guid.NewGuid().ToString();
         var path = Path.Combine(DirectoryPath, name);
         _ = Directory.CreateDirectory(path);
         return path;

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -175,8 +175,8 @@ public sealed class CompilerLogReader : IDisposable
 
     public CompilerCall ReadCompilerCall(int index)
     {
-        if (index >= Count)
-            throw new InvalidOperationException();
+        if (index < 0 || index >= Count)
+            throw new ArgumentException("Invalid index", nameof(index));
 
         return ReadCompilerCallCore(index, GetOrReadCompilationInfo(index));
     }
@@ -452,7 +452,7 @@ public sealed class CompilerLogReader : IDisposable
 
     internal int GetIndex(CompilerCall compilerCall)
     {
-        if (compilerCall.Index is int i && i < Count)
+        if (compilerCall.Index is int i && i >= 0 && i < Count)
         {
             return i;
         }
@@ -614,12 +614,6 @@ public sealed class CompilerLogReader : IDisposable
 
     internal Stream GetContentStream(string contentHash) =>
         ZipArchive.OpenEntryOrThrow(GetContentEntryName(contentHash));
-
-    internal void CopyContentTo(string contentHash, Stream destination)
-    {
-        using var stream = ZipArchive.OpenEntryOrThrow(GetContentEntryName(contentHash));
-        stream.CopyTo(destination);
-    }
 
     internal ResourceDescription ReadResourceDescription(RawResourceData data)
     {

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -28,8 +28,12 @@ public sealed class CompilerLogReader : IDisposable
     private readonly Dictionary<Guid, MetadataReference> _refMap = new();
     private readonly Dictionary<Guid, (string FileName, AssemblyName AssemblyName)> _mvidToRefInfoMap = new();
     private readonly Dictionary<string, BasicAnalyzerHost> _analyzersMap = new();
-    private readonly bool _ownsCompilerLogState;
     private readonly Dictionary<int, CompilationInfoPack> _compilationInfoMap = new();
+
+    /// <summary>
+    /// Is this reader responsible for disposing the <see cref="CompilerLogState"/> instance
+    /// </summary>
+    public bool OwnsCompilerLogState { get; }
 
     public BasicAnalyzerHostOptions BasicAnalyzerHostOptions { get; }
     internal CompilerLogState CompilerLogState { get; }
@@ -43,8 +47,8 @@ public sealed class CompilerLogReader : IDisposable
     private CompilerLogReader(ZipArchive zipArchive, Metadata metadata, BasicAnalyzerHostOptions basicAnalyzersOptions, CompilerLogState? state)
     {
         _zipArchiveCore = zipArchive;
+        OwnsCompilerLogState = state is null;
         CompilerLogState = state ?? new CompilerLogState();
-        _ownsCompilerLogState = state is null;
         BasicAnalyzerHostOptions = basicAnalyzersOptions;
         Metadata = metadata;
         ReadAssemblyInfo();
@@ -140,7 +144,7 @@ public sealed class CompilerLogReader : IDisposable
             .ToList();
         var resources = dataPack
             .Resources
-            .Select(x => new RawResourceData(x.ContentHash, CreateResourceDescription(this, x)))
+            .Select(x => new RawResourceData(x.Name, x.FileName, x.IsPublic, x.ContentHash))
             .ToList();
 
         return new RawCompilationData(
@@ -156,19 +160,6 @@ public sealed class CompilerLogReader : IDisposable
             resources,
             pack.IsCSharp,
             dataPack.IncludesGeneratedText);
-
-        static ResourceDescription CreateResourceDescription(CompilerLogReader reader, ResourcePack pack)
-        {
-            var dataProvider = () =>
-            {
-                var bytes = reader.GetContentBytes(pack.ContentHash);
-                return new MemoryStream(bytes);
-            };
-
-            return string.IsNullOrEmpty(pack.FileName)
-                ? new ResourceDescription(pack.Name, dataProvider, pack.IsPublic)
-                : new ResourceDescription(pack.Name, pack.FileName, dataProvider, pack.IsPublic);
-        }
     }
 
     private CompilationInfoPack GetOrReadCompilationInfo(int index)
@@ -245,7 +236,7 @@ public sealed class CompilerLogReader : IDisposable
     {
         var pack = GetOrReadCompilationInfo(GetIndex(compilerCall));
         var rawCompilationData = ReadRawCompilationData(compilerCall);
-        var referenceList = GetMetadataReferences(rawCompilationData.References);
+        var referenceList = RenameMetadataReferences(rawCompilationData.References);
         var (emitOptions, rawParseOptions, compilationOptions) = ReadCompilerOptions(pack);
 
         var hashAlgorithm = rawCompilationData.ChecksumAlgorithm;
@@ -257,7 +248,7 @@ public sealed class CompilerLogReader : IDisposable
         Stream? sourceLinkStream = null;
         List<ResourceDescription>? resources = rawCompilationData.Resources.Count == 0
             ? null
-            : rawCompilationData.Resources.Select(x => x.ResourceDescription).ToList();
+            : rawCompilationData.Resources.Select(x => ReadResourceDescription(x)).ToList();
         List<EmbeddedText>? embeddedTexts = null;
 
         foreach (var rawContent in rawCompilationData.Contents)
@@ -282,10 +273,10 @@ public sealed class CompilerLogReader : IDisposable
                     HandleCryptoKeyFile(rawContent.ContentHash);
                     break;
                 case RawContentKind.SourceLink:
-                    sourceLinkStream = GetStateAwareContentStream(rawContent.ContentHash);
+                    sourceLinkStream = GetContentBytes(rawContent.ContentHash).AsSimpleMemoryStream(writable: false);
                     break;
                 case RawContentKind.Win32Resource:
-                    win32ResourceStream = GetStateAwareContentStream(rawContent.ContentHash);
+                    win32ResourceStream = GetContentBytes(rawContent.ContentHash).AsSimpleMemoryStream(writable: false);
                     break;
                 case RawContentKind.Embed:
                 {
@@ -572,7 +563,7 @@ public sealed class CompilerLogReader : IDisposable
         throw new ArgumentException($"{mvid} is not a valid MVID");
     }
 
-    internal MetadataReference GetMetadataReference(Guid mvid)
+    internal MetadataReference ReadMetadataReference(Guid mvid)
     {
         if (_refMap.TryGetValue(mvid, out var metadataReference))
         {
@@ -586,9 +577,9 @@ public sealed class CompilerLogReader : IDisposable
         return metadataReference;
     }
 
-    internal MetadataReference GetMetadataReference(in RawReferenceData data)
+    internal MetadataReference RenameMetadataReference(in RawReferenceData data)
     {
-        var reference = GetMetadataReference(data.Mvid);
+        var reference = ReadMetadataReference(data.Mvid);
         if (data.EmbedInteropTypes)
         {
             reference = reference.WithEmbedInteropTypes(true);
@@ -602,12 +593,12 @@ public sealed class CompilerLogReader : IDisposable
         return reference;
     }
 
-    internal List<MetadataReference> GetMetadataReferences(List<RawReferenceData> referenceDataList)
+    internal List<MetadataReference> RenameMetadataReferences(List<RawReferenceData> referenceDataList)
     {
         var list = new List<MetadataReference>(capacity: referenceDataList.Count);
         foreach (var referenceData in referenceDataList)
         {
-            list.Add(GetMetadataReference(referenceData));
+            list.Add(RenameMetadataReference(referenceData));
         }
         return list;
     }
@@ -630,21 +621,13 @@ public sealed class CompilerLogReader : IDisposable
         stream.CopyTo(destination);
     }
 
-    /// <summary>
-    /// This gets a content <see cref="Stream"/> instance that is aware of the state
-    /// lifetime. If the <see cref="CompilerLogState" /> is owned by this instance then 
-    /// it's safe to expose streams into the underlying zip. Otherwise a copy is created
-    /// to ensure it's safe to use after this zip is closed
-    /// </summary>
-    internal Stream GetStateAwareContentStream(string contentHash)
+    internal ResourceDescription ReadResourceDescription(RawResourceData data)
     {
-        if (_ownsCompilerLogState)
-        {
-            return GetContentStream(contentHash);
-        }
-
-        var bytes = GetContentBytes(contentHash);
-        return bytes.AsSimpleMemoryStream(writable: false);
+        var stream = GetContentBytes(data.ContentHash).AsSimpleMemoryStream(writable: false);
+        var dataProvider = () => stream;
+        return string.IsNullOrEmpty(data.FileName)
+            ? new ResourceDescription(data.Name, dataProvider, data.IsPublic)
+            : new ResourceDescription(data.Name, data.FileName, dataProvider, data.IsPublic);
     }
 
     internal SourceText GetSourceText(string contentHash, SourceHashAlgorithm checksumAlgorithm, bool canBeEmbedded = false)
@@ -693,7 +676,7 @@ public sealed class CompilerLogReader : IDisposable
         ZipArchive.Dispose();
         _zipArchiveCore = null!;
 
-        if (_ownsCompilerLogState)
+        if (OwnsCompilerLogState)
         {
             CompilerLogState.Dispose();
         }

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -333,7 +333,7 @@ public sealed class ExportUtil
                 // The name of file resources isn't that important. It doesn't contribute to the compilation 
                 // output. What is important is all the other parts of the string. Just need to create a
                 // unique name inside the embedded resource folder
-                var d = resourceData.ResourceDescription;
+                var d = Reader.ReadResourceDescription(resourceData);
                 var originalFileName = d.GetFileName();
                 var resourceName = d.GetResourceName();
                 var filePath = Path.Combine(builder.EmbeddedResourceDirectory, resourceData.ContentHash, originalFileName ?? resourceName);

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -63,13 +63,17 @@ internal readonly struct RawReferenceData
 
 internal readonly struct RawResourceData
 {
+    internal readonly string Name;
+    internal readonly string? FileName;
+    internal readonly bool IsPublic;
     internal readonly string ContentHash; 
-    internal readonly ResourceDescription ResourceDescription;
 
-    internal RawResourceData(string contentHash, ResourceDescription d)
+    internal RawResourceData(string name, string? fileName, bool isPublic, string contentHash)
     {
+        Name = name;
+        FileName = fileName;
+        IsPublic = isPublic;
         ContentHash = contentHash;
-        ResourceDescription = d;
     }
 }
 

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -120,7 +120,7 @@ public sealed class SolutionReader : IDisposable
         // here and setup in the Workspace
         var projectReferences = new List<ProjectReference>();
 
-        var referenceList = Reader.GetMetadataReferences(FilterToUnique(rawCompilationData.References));
+        var referenceList = Reader.RenameMetadataReferences(FilterToUnique(rawCompilationData.References));
         var analyzers = Reader.ReadAnalyzers(rawCompilationData);
         var options = Reader.ReadCompilerOptions(compilerCall);
         var projectInfo = ProjectInfo.Create(


### PR DESCRIPTION
The `CompilationData` returned from a `CompilerLogReader` need to be tied to the state not the reader if the state isn't owned by the reader.