### PR TITLE
Fix bug in none host

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -245,14 +245,14 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
-    public void NoneHostAddsFakeGeneratorForGeneratedSource()
+    public void NoneHostHasNoGenerators()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
         var compilation1 = data.Compilation;
         var compilation2 = data.GetCompilationAfterGenerators();
-        Assert.NotSame(compilation1, compilation2);
-        Assert.Single(data.AnalyzerReferences);
+        Assert.Same(compilation1, compilation2);
+        Assert.Empty(data.AnalyzerReferences);
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -125,7 +125,7 @@ public sealed class ExportUtilTests : TestBase
             Assert.True(foundPath);
 
             var analyzers = Directory.GetFiles(Path.Combine(tempPath, "analyzers"), "*.dll", SearchOption.AllDirectories).ToList();
-            Assert.Equal(7, analyzers.Count);
+            Assert.Empty(analyzers);
         }, runBuild: false);
     }
 

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -49,7 +49,8 @@ public sealed class SolutionReaderTests : TestBase
         Assert.Empty(project.AnalyzerReferences);
         var docs = project.Documents.ToList();
         var generatedDocs = (await project.GetSourceGeneratedDocumentsAsync()).ToList();
-        Assert.NotNull(docs.First(x => x.Name == "RegexGenerator.g.cs"));
+        Assert.Equal(5, docs.Count);
+        Assert.Equal("RegexGenerator.g.cs", docs.Last().Name);
         Assert.Empty(generatedDocs);
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -22,19 +22,34 @@ public sealed class SolutionReaderTests : TestBase
         Fixture = fixture;
     }
 
-    [Theory]
-    [InlineData(BasicAnalyzerKind.Default)]
-    [InlineData(BasicAnalyzerKind.None)]
-    public async Task DocumentsHaveGeneratedTextWithAnalyzers(BasicAnalyzerKind kind)
+    [Fact]
+    public async Task DocumentsGeneratedDefaultHost()
     {
-        var host = new BasicAnalyzerHostOptions(kind);
+        var host = new BasicAnalyzerHostOptions(BasicAnalyzerKind.Default);
         using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath.Value, host);
         var workspace = new AdhocWorkspace();
         var solution = workspace.AddSolution(reader.ReadSolutionInfo());
         var project = solution.Projects.Single();
         Assert.NotEmpty(project.AnalyzerReferences);
-        var docs = await project.GetSourceGeneratedDocumentsAsync();
-        var doc = docs.First(x => x.Name == "RegexGenerator.g.cs");
-        Assert.NotNull(doc);
+        var docs = project.Documents.ToList();
+        var generatedDocs = (await project.GetSourceGeneratedDocumentsAsync()).ToList();
+        Assert.Null(docs.FirstOrDefault(x => x.Name == "RegexGenerator.g.cs"));
+        Assert.Single(generatedDocs);
+        Assert.NotNull(generatedDocs.First(x => x.Name == "RegexGenerator.g.cs"));
+    }
+
+    [Fact]
+    public async Task DocumentsGeneratedNoneHost()
+    {
+        var host = new BasicAnalyzerHostOptions(BasicAnalyzerKind.None);
+        using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath.Value, host);
+        var workspace = new AdhocWorkspace();
+        var solution = workspace.AddSolution(reader.ReadSolutionInfo());
+        var project = solution.Projects.Single();
+        Assert.Empty(project.AnalyzerReferences);
+        var docs = project.Documents.ToList();
+        var generatedDocs = (await project.GetSourceGeneratedDocumentsAsync()).ToList();
+        Assert.NotNull(docs.First(x => x.Name == "RegexGenerator.g.cs"));
+        Assert.Empty(generatedDocs);
     }
 }

--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.xml
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.xml
@@ -40,8 +40,8 @@
         <member name="F:Basic.CompilerLog.Util.BasicAnalyzerKind.None">
             <summary>
             Analyzers and generators from the original are not loaded at all. In the case 
-            the original build had generated files they will be added through an in 
-            memory analyzer that just adds them directly.
+            the original build had generated files they are just added directly to the
+            compilation.
             </summary>
             <remarks>
             This option avoids loading third party analyzers and generators.
@@ -316,6 +316,32 @@
             Replace the <paramref name="oldStart"/> with <paramref name="newStart"/> inside of
             <paramref name="filePath"/>
             </summary>
+        </member>
+    </members>
+</doc>
+System.Diagnostics.CodeAnalysis.NotNullWhenAttribute">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>Initializes the attribute with the specified return value condition.</summary>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter will not be null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue">
+            <summary>Gets the return value condition.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute">
+            <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.#ctor(System.String)">
+            <summary>Initializes the attribute with the associated parameter name.</summary>
+            <param name="parameterName">
+            The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.ParameterName">
+            <summary>Gets the associated parameter name.</summary>
         </member>
     </members>
 </doc>

--- a/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
+++ b/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
@@ -120,8 +120,8 @@ public enum BasicAnalyzerKind
 
     /// <summary>
     /// Analyzers and generators from the original are not loaded at all. In the case 
-    /// the original build had generated files they will be added through an in 
-    /// memory analyzer that just adds them directly.
+    /// the original build had generated files they are just added directly to the
+    /// compilation.
     /// </summary>
     /// <remarks>
     /// This option avoids loading third party analyzers and generators.

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -258,16 +258,17 @@ public sealed class ExportUtil
 
         void WriteAnalyzers()
         {
+            if (!IncludeAnalyzers)
+            {
+                return;
+            }
+
             foreach (var analyzer in data.Analyzers)
             {
                 using var analyzerStream = Reader.GetAssemblyStream(analyzer.Mvid);
                 var filePath = builder.AnalyzerDirectory.WriteContent(analyzer.FilePath, analyzerStream);
-
-                if (IncludeAnalyzers)
-                {
-                    var arg = $@"/analyzer:""{PathUtil.RemovePathStart(filePath, builder.DestinationDirectory)}""";
-                    commandLineList.Add(arg);
-                }
+                var arg = $@"/analyzer:""{PathUtil.RemovePathStart(filePath, builder.DestinationDirectory)}""";
+                commandLineList.Add(arg);
             }
         }
 

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
@@ -29,9 +29,12 @@ internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
     {
         ReadGeneratedFiles = readGeneratedFiles;
         GeneratedSourceTexts = generatedSourceTexts;
-        AnalyzerReferencesCore = readGeneratedFiles && generatedSourceTexts.Length == 0
-            ? ImmutableArray<AnalyzerReference>.Empty
-            : ImmutableArray.Create<AnalyzerReference>(new NoneAnalyzerReference(readGeneratedFiles, generatedSourceTexts));
+        AnalyzerReferencesCore = ImmutableArray<AnalyzerReference>.Empty;
+
+        if (!ReadGeneratedFiles)
+        {
+            AddDiagnostic(Diagnostic.Create(CannotReadGeneratedFiles, Location.None));
+        }
     }
 
     protected override void DisposeCore()

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -72,6 +72,7 @@ public sealed class SolutionReader : IDisposable
         var documents = new List<DocumentInfo>();
         var additionalDocuments = new List<DocumentInfo>();
         var analyzerConfigDocuments = new List<DocumentInfo>();
+        var generatedFiles = new List<DocumentInfo>();
 
         foreach (var tuple in rawCompilationData.Contents)
         {
@@ -85,7 +86,7 @@ public sealed class SolutionReader : IDisposable
                     // doesn't have generators then we need to add them as documents now.
                     if (Reader.BasicAnalyzerHostOptions.Kind == BasicAnalyzerKind.None)
                     {
-                        Add(documents);
+                        Add(generatedFiles);
                     }
                     break;
                 case RawContentKind.AdditionalText:
@@ -119,6 +120,9 @@ public sealed class SolutionReader : IDisposable
                     filePath: tuple.FilePath));
             }
         }
+
+        // Generated files should appear last
+        documents.AddRange(generatedFiles);
 
         // https://github.com/jaredpar/complog/issues/24
         // Need to store project reference information at the builder point so they can be properly repacked

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -81,7 +81,12 @@ public sealed class SolutionReader : IDisposable
                     Add(documents);
                     break;
                 case RawContentKind.GeneratedText:
-                    // Handled when creating analyzer host.
+                    // When the host has generators these will be added as generators are run. If the host 
+                    // doesn't have generators then we need to add them as documents now.
+                    if (Reader.BasicAnalyzerHostOptions.Kind == BasicAnalyzerKind.None)
+                    {
+                        Add(documents);
+                    }
                     break;
                 case RawContentKind.AdditionalText:
                     Add(additionalDocuments);


### PR DESCRIPTION
The `SolutionReader` was not promptly putting generated files into the `Project` when the none host was enabled. Looking into this made me realize the code wasn't treating none host strongly enough in a few places so fixed those as well.