### PR TITLE
Map global editor config sections

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -209,7 +209,8 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                   </PropertyGroup>
                   <ItemGroup>
                     <EmbeddedResource Include="resource.txt" />
-                    <AdditionalFiles Include="additional.txt" />
+                    <AdditionalFiles Include="additional.txt" FixtureKey="true" />
+                    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="FixtureKey" />
                   </ItemGroup>
                 </Project>
                 """, TestBase.DefaultEncoding);

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -66,6 +66,18 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
+    public void GlobalConfigPathMap()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplexComplogPath.Value);
+        var data = reader.ReadCompilationData(0);
+        var provider = (BasicAnalyzerConfigOptionsProvider)data.AnalyzerConfigOptionsProvider;
+        var additonalText = data.AdditionalTexts.Single(x => x.Path.Contains("additional.txt"));
+        var options = provider.GetOptions(additonalText);
+        Assert.True(options.TryGetValue("build_metadata.AdditionalFiles.FixtureKey", out var value));
+        Assert.Equal("true", value);
+    }
+
+    [Fact]
     public void MetadataVersion()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value);

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -129,6 +129,33 @@ public sealed class ExportUtilTests : TestBase
         }, runBuild: false);
     }
 
+    /// <summary>
+    /// Make sure that global configs get their full paths mapped to the new location on disk
+    /// </summary>
+    [Fact]
+    public void GlobalConfigMapsPaths()
+    {
+        TestExport(Fixture.ConsoleComplexComplogPath.Value, expectedCount: 1, verifyExportCallback: void (string path) =>
+        {
+            var configFilePath = Directory
+                .EnumerateFiles(path, "console-complex.GeneratedMSBuildEditorConfig.editorconfig", SearchOption.AllDirectories)
+                .Single();
+            
+            var found = false;
+            var pattern = $"[{path}";
+            foreach (var line in File.ReadAllLines(configFilePath))
+            {
+                if (line.StartsWith(pattern, StringComparison.Ordinal))
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.True(found);
+        }, runBuild: true);
+    }
+
     [Fact]
     public void ConsoleMultiTarget()
     {

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -1,5 +1,6 @@
 using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;
 
@@ -7,6 +8,77 @@ namespace Basic.CompilerLog.UnitTests;
 
 public sealed class RoslynUtilTests
 {
+    public static IEnumerable<object[]> GetIsGlobalConfigData()
+    {
+        yield return new object[]
+        { 
+            true,
+            """
+            is_global = true
+            """
+        };
+
+        yield return new object[]
+        { 
+            false,
+            """
+            is_global = false
+            """
+        };
+
+        yield return new object[]
+        { 
+            true,
+            """
+            is_global = false
+            is_global = true
+            """
+        };
+
+        // Don't read past the first section
+        yield return new object[]
+        { 
+            false,
+            """
+            [c:\example.cs]
+            is_global = false
+            is_global = true
+            """
+        };
+
+        // ignore comments
+        yield return new object[]
+        { 
+            false,
+            """
+            ;is_global = true
+            a = 3
+            """
+        };
+
+        // Super long lines
+        yield return new object[]
+        { 
+            false,
+            $"""
+            ;{new string('a', 1000)}
+            ;is_global = true
+            a = 3
+            """
+        };
+
+        // Super long lines
+        yield return new object[]
+        { 
+            true,
+            $"""
+            ;{new string('a', 1000)}
+            is_global = true
+            a = 3
+            """
+        };
+    }
+
     [Fact]
     public void ParseAllVisualBasicEmpty()
     {
@@ -19,5 +91,14 @@ public sealed class RoslynUtilTests
     {
         var result = RoslynUtil.ParseAllCSharp([], CSharpParseOptions.Default);
         Assert.Empty(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetIsGlobalConfigData))]
+    public void IsGlobalConfig(bool expected, string contents)
+    {
+        var sourceText = SourceText.From(contents);
+        var actual = RoslynUtil.IsGlobalEditorConfig(sourceText);
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -91,6 +91,7 @@ public sealed class RoslynUtilTests
                 ;{new string('a', 1000)}
                 is_global = true
                 a = 3
+                [section]
                 """,
                 index++);
         }

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -108,6 +108,7 @@ public sealed class RoslynUtilTests
                 "\r",
                 "\u2028",
                 "\u2029",
+                $"{(char)0x85}"
             ];
 
             foreach (var newLine in newLines)

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -24,9 +24,17 @@ public sealed class RoslynUtilTests
         {
             var index = 0;
             yield return new IsGlobalConfigData(
+                false,
+                """
+                is_global = true
+                """,
+                index++);
+
+            yield return new IsGlobalConfigData(
                 true,
                 """
                 is_global = true
+                [examlpe]
                 """,
                 index++);
 
@@ -42,6 +50,7 @@ public sealed class RoslynUtilTests
                 """
                 is_global = false
                 is_global = true
+                [example]
                 """,
                 index++);
 
@@ -61,6 +70,7 @@ public sealed class RoslynUtilTests
                 """
                 ;is_global = true
                 a = 3
+                [section]
                 """,
                 index++);
 
@@ -105,7 +115,7 @@ public sealed class RoslynUtilTests
     public void IsGlobalConfig(IsGlobalConfigData data)
     {
         var sourceText = SourceText.From(data.Contents);
-        var actual = RoslynUtil.IsGlobalEditorConfig(sourceText);
+        var actual = RoslynUtil.IsGlobalEditorConfigWithSection(sourceText);
         Assert.Equal(data.IsExpect, actual);
     }
 
@@ -137,7 +147,7 @@ public sealed class RoslynUtilTests
         void Core(string content, string expected, Func<string, string> mapFunc)
         {
             var sourceText = SourceText.From(content);
-            var actual = RoslynUtil.RewriteGlobalEditorConfigPaths(sourceText, mapFunc);
+            var actual = RoslynUtil.RewriteGlobalEditorConfigSections(sourceText, mapFunc);
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -25,6 +25,11 @@ public sealed class RoslynUtilTests
             var index = 0;
             yield return new IsGlobalConfigData(
                 false,
+                "",
+                index++);
+
+            yield return new IsGlobalConfigData(
+                false,
                 """
                 is_global = true
                 """,
@@ -94,6 +99,25 @@ public sealed class RoslynUtilTests
                 [section]
                 """,
                 index++);
+
+            // Every new line combination
+            string[] newLines = 
+            [
+                "\r\n",
+                "\n",
+                "\r",
+                "\u2028",
+                "\u2029",
+            ];
+
+            foreach (var newLine in newLines)
+            {
+                var content = $"is_global = true{newLine}[section]";
+                yield return new IsGlobalConfigData(
+                    true,
+                    content,
+                    index++);
+            }
         }
     }
 

--- a/src/Basic.CompilerLog.Util/Extensions.cs
+++ b/src/Basic.CompilerLog.Util/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Basic.CompilerLog.Util/Polyfill.cs
+++ b/src/Basic.CompilerLog.Util/Polyfill.cs
@@ -41,6 +41,14 @@ namespace Basic.CompilerLog.Util
         internal static string[] Split(this string @this, char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
             @this.Split(new char[] { separator }, count, options);
 
+        internal static void Append(this StringBuilder @this, ReadOnlySpan<char> value)
+        {
+            foreach (var c in value)
+            {
+                @this.Append(c);
+            }
+        }
+
         internal static bool StartsWith(this ReadOnlySpan<char> @this, string value, StringComparison comparisonType) =>
             @this.StartsWith(value.AsSpan(), comparisonType);
 

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -64,7 +64,7 @@ internal static class RoslynUtil
         return syntaxTrees;
     }
 
-    internal static string RewriteGlobalEditorConfigPaths(SourceText sourceText, Func<string, string> pathMapFunc)
+    internal static string RewriteGlobalEditorConfigSections(SourceText sourceText, Func<string, string> pathMapFunc)
     {
         var builder = new StringBuilder();
         ForEachLine(sourceText, (line, newLine) =>
@@ -98,9 +98,10 @@ internal static class RoslynUtil
         return builder.ToString();
     }
 
-    internal static bool IsGlobalEditorConfig(SourceText sourceText)
+    internal static bool IsGlobalEditorConfigWithSection(SourceText sourceText)
     {
         var isGlobal = false;
+        var hasSection = false;
         ForEachLine(sourceText, (line, _) =>
         {
             SkipWhiteSpace(ref line);
@@ -112,18 +113,19 @@ internal static class RoslynUtil
             if (IsGlobalConfigEntry(line))
             {
                 isGlobal = true;
-                return false;
+                return true;
             }
 
             if (IsSectionStart(line))
             {
+                hasSection = true;
                 return false;
             }
 
             return true;
         });
 
-        return isGlobal;
+        return isGlobal && hasSection;
 
         static bool IsGlobalConfigEntry(ReadOnlySpan<char> span) => 
             IsMatch(ref span, "is_global") &&

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -3,15 +3,19 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace Basic.CompilerLog.Util;
 
 internal static class RoslynUtil
 {
+    internal delegate bool SourceTextLineFunc(ReadOnlySpan<char> line, ReadOnlySpan<char> newLine);
+
     /// <summary>
     /// Get a source text 
     /// </summary>
@@ -58,5 +62,155 @@ internal static class RoslynUtil
                 syntaxTrees[i] = (CSharpSyntaxTree)CSharpSyntaxTree.ParseText(t.SourceText, parseOptions, t.Path);
             });
         return syntaxTrees;
+    }
+
+    internal static bool IsGlobalEditorConfig(SourceText sourceText)
+    {
+        var isGlobal = false;
+        ForEachLine(sourceText, (line, _) =>
+        {
+            SkipWhiteSpace(ref line);
+            if (line.Length == 0)
+            {
+                return true;
+            }
+
+            if (IsGlobalConfigEntry(line))
+            {
+                isGlobal = true;
+                return false;
+            }
+
+            if (IsSectionStart(line))
+            {
+                return false;
+            }
+
+            return true;
+        });
+
+        return isGlobal;
+
+        static bool IsGlobalConfigEntry(ReadOnlySpan<char> span) => 
+            IsMatch(ref span, "is_global") &&
+            IsMatch(ref span, "=") &&
+            IsMatch(ref span, "true");
+
+        static bool IsSectionStart(ReadOnlySpan<char> span) => 
+            IsMatch(ref span, "[");
+
+        static bool IsMatch(ref ReadOnlySpan<char> span, string value)
+        {
+            SkipWhiteSpace(ref span);
+            if (span.Length < value.Length)
+            {
+                return false;
+            }
+
+            if (span.Slice(0, value.Length).SequenceEqual(value.AsSpan()))
+            {
+                span = span.Slice(value.Length);
+                return true;
+            }
+
+            return false;
+        }
+
+        static void SkipWhiteSpace(ref ReadOnlySpan<char> span)
+        {
+            while (span.Length > 0 && char.IsWhiteSpace(span[0]))
+            {
+                span = span.Slice(1);
+            }
+        }
+    }
+
+    internal static void ForEachLine(SourceText sourceText, SourceTextLineFunc func)
+    {
+        var pool = ArrayPool<char>.Shared;
+        var buffer = pool.Rent(256);
+        int sourceIndex = 0;
+
+        if (sourceText.Length == 0)
+        {
+            return;
+        }
+
+        Span<char> line;
+        Span<char> newLine;
+        do
+        {
+            var (newLineIndex, newLineLength) = ReadNextLine();
+            line = buffer.AsSpan(0, newLineIndex);
+            newLine = buffer.AsSpan(newLineIndex, newLineLength);
+            if (!func(line, newLine))
+            {
+                return;
+            }
+
+            sourceIndex += newLineIndex + newLineLength;
+        } while (newLine.Length > 0);
+
+        pool.Return(buffer);
+
+        (int NewLineIndex, int NewLineLength) ReadNextLine()
+        {
+            while (true)
+            {
+                var count = Math.Min(sourceText.Length - sourceIndex, buffer.Length);
+                sourceText.CopyTo(sourceIndex, buffer, 0, count);
+
+                var (newLineIndex, newLineLength) = FindNewLineInBuffer(count);
+                if (newLineIndex < 0)
+                {
+                    // Read the entire source text so there are no more new lines. The newline is the end 
+                    // of the buffer with length 0.
+                    if (count < buffer.Length)
+                    {
+                        return (count, 0);
+                    }
+
+                    var size = buffer.Length * 2;
+                    pool.Return(buffer);
+                    buffer = pool.Rent(size);
+                }
+                else
+                {
+                    return (newLineIndex, newLineLength);
+                }
+            }
+        }
+
+        (int Index, int Length) FindNewLineInBuffer(int count)
+        {
+            int index = 0;
+
+            // The +1 is to account for the fact that newlines can be 2 characters long.
+            while (index + 1 < count)
+            {
+                var span = buffer.AsSpan(index, count - index);
+                var length = GetNewlineLength(span);
+                if (length > 0)
+                {
+                    return (index, length);
+                }
+
+                index++;
+            }
+
+            return (-1, -1);
+        }
+
+
+        static int GetNewlineLength(Span<char> span) => 
+            span[0] switch
+            {
+                '\r' => span.Length > 1 && span[1] == '\n' ? 2 : 1,
+                '\n' => 1,
+                '\u2028' => 1,
+                '\u2029' => 1,
+                (char)(0x85) => 1,
+                _ => 0
+            };
     }
 }

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -64,6 +64,40 @@ internal static class RoslynUtil
         return syntaxTrees;
     }
 
+    internal static string RewriteGlobalEditorConfigPaths(SourceText sourceText, Func<string, string> pathMapFunc)
+    {
+        var builder = new StringBuilder();
+        ForEachLine(sourceText, (line, newLine) =>
+        {
+            if (line.Length == 0)
+            {
+                builder.Append(newLine);
+                return true;
+            }
+
+            if (line[0] == '[')
+            {
+                var index = line.IndexOf(']');
+                if (index > 0)
+                {
+                    var mapped = pathMapFunc(line.Slice(1, index - 1).ToString());
+                    builder.Append('[');
+                    builder.Append(mapped);
+                    builder.Append(line.Slice(index));
+                }
+            }
+            else
+            {
+                builder.Append(line);
+            }
+
+            builder.Append(newLine);
+            return true;
+        });
+
+        return builder.ToString();
+    }
+
     internal static bool IsGlobalEditorConfig(SourceText sourceText)
     {
         var isGlobal = false;


### PR DESCRIPTION
The `[ ... ]` in global editor configs have full paths written to them. That presents a problem when either: 

1. Opening a compiler log created on Windows in Linux (or vice versa)
2. Exporting a compiler log to disk

In both cases the paths of the files in the compilation will be different from the original values in the global config sections. Need to map them to keep it consistent. 

closes #110 
