### PR TITLE
Store compiler information

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,10 +11,13 @@
         "Complogs",
         "cryptodir",
         "cryptokeyfile",
+        "inmemory",
         "jaredpar",
         "msbuild",
         "Mvid",
         "NETCOREAPP",
+        "netstandard",
+        "ondisk",
         "Relogger",
         "ruleset",
         "Xunit"

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogUtilTests.cs
@@ -21,13 +21,14 @@ namespace Basic.CompilerLog.UnitTests;
 public sealed class BinaryLogUtilTests
 {
     [Theory]
-    [InlineData("dotnet exec csc.dll a.cs", "a.cs")]
-    [InlineData("dotnet not what we expect a.cs", "")]
-    [InlineData("csc.exe a.cs b.cs", "a.cs b.cs")]
-    public void SkipCompilerExecutableTests(string args, string expected)
+    [InlineData("dotnet exec csc.dll a.cs", null, "a.cs")]
+    [InlineData("dotnet not what we expect a.cs", null, "")]
+    [InlineData("csc.exe a.cs b.cs", null, "a.cs b.cs")]
+    public void ParseCompilerAndArguments(string inputArgs, string? expectedCompilerFilePath, string expectedArgs)
     {
-        var realArgs = BinaryLogUtil.SkipCompilerExecutable(ToArray(args), "csc.exe", "csc.dll");
-        Assert.Equal(ToArray(expected), realArgs);
+        var (actualCompilerFilePath, actualArgs) = BinaryLogUtil.ParseCompilerAndArguments(ToArray(inputArgs), "csc.exe", "csc.dll");
+        Assert.Equal(ToArray(expectedArgs), actualArgs);
+        Assert.Equal(expectedCompilerFilePath, actualCompilerFilePath);
         static string[] ToArray(string arg) => arg.Split(new char[]{' '}, StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogUtilTests.cs
@@ -21,9 +21,9 @@ namespace Basic.CompilerLog.UnitTests;
 public sealed class BinaryLogUtilTests
 {
     [Theory]
-    [InlineData("dotnet exec csc.dll a.cs", null, "a.cs")]
+    [InlineData("dotnet exec csc.dll a.cs", "csc.dll", "a.cs")]
     [InlineData("dotnet not what we expect a.cs", null, "")]
-    [InlineData("csc.exe a.cs b.cs", null, "a.cs b.cs")]
+    [InlineData("csc.exe a.cs b.cs", "csc.exe", "a.cs b.cs")]
     public void ParseCompilerAndArguments(string inputArgs, string? expectedCompilerFilePath, string expectedArgs)
     {
         var (actualCompilerFilePath, actualArgs) = BinaryLogUtil.ParseCompilerAndArguments(ToArray(inputArgs), "csc.exe", "csc.dll");

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -31,7 +31,7 @@ public sealed class CompilerLogBuilderTests : TestBase
             isCSharp: true,
             new Lazy<string[]>(() => ["/sourcelink:does-not-exist.txt"]),
             null);
-        builder.Add(compilerCall);
+        Assert.Throws<Exception>(() => builder.Add(compilerCall));
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -35,6 +35,26 @@ public sealed class CompilerLogBuilderTests : TestBase
     }
 
     [Fact]
+    public void AddWithMissingCompilerFilePath()
+    {
+        using var stream = new MemoryStream();
+        using var builder = new CompilerLogBuilder(stream, new());
+        using var binlogStream = new FileStream(Fixture.ConsoleWithDiagnosticsBinaryLogPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        var compilerCall = BinaryLogUtil.ReadAllCompilerCalls(binlogStream, new()).First(x => x.IsCSharp);
+        var args = compilerCall.GetArguments();
+        compilerCall = new CompilerCall(
+            compilerFilePath: null,
+            compilerCall.ProjectFilePath,
+            CompilerCallKind.Regular,
+            compilerCall.TargetFramework,
+            isCSharp: true,
+            new Lazy<string[]>(() => args),
+            null);
+        builder.Add(compilerCall);
+    }
+
+    [Fact]
     public void PortablePdbMissing()
     {
         RunDotNet("new console -o .");

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -24,6 +24,7 @@ public sealed class CompilerLogBuilderTests : TestBase
 
         var compilerCall = BinaryLogUtil.ReadAllCompilerCalls(binlogStream, new()).First(x => x.IsCSharp);
         compilerCall = new CompilerCall(
+            compilerCall.CompilerFilePath,
             compilerCall.ProjectFilePath,
             CompilerCallKind.Regular,
             compilerCall.TargetFramework,

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
@@ -65,6 +65,7 @@ public sealed class CompilerLogReaderExTests : TestBase
         {
             var args = func(x.GetArguments());
             return new CompilerCall(
+                x.CompilerFilePath,
                 x.ProjectFilePath,
                 x.Kind,
                 x.TargetFramework,

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -499,7 +500,7 @@ public sealed class ProgramTests : TestBase
     }
 
     [Fact]
-    public void RelpayBadOptionCombination()
+    public void ReplayBadOptionCombination()
     {
         var (exitCode, output) = RunCompLogEx($"replay -o example");
         Assert.Equal(Constants.ExitFailure, exitCode);
@@ -534,8 +535,23 @@ public sealed class ProgramTests : TestBase
         Assert.Contains("classlib.csproj (net7.0)", output);
     }
 
+    [Fact]
+    public void PrintCompilers()
+    {
+        var (exitCode, output) = RunCompLogEx($"print {Fixture.SolutionBinaryLogPath} -c");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleWithDiagnosticsBinaryLogPath);
+        var tuple = reader.ReadAllCompilerAssemblies().Single();
+        Assert.Contains($"""
+            Compilers
+            {tuple.CompilerFilePath}
+            {tuple.AssemblyName}
+            """, output);
+    }
+
     /// <summary>
-    /// Engage the code to find files in the specidied directory
+    /// Engage the code to find files in the specified directory
     /// </summary>
     [Fact]
     public void PrintDirectory()

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -111,7 +111,17 @@ public sealed class UsingAllCompilerLogTests : TestBase
             using var reader = CompilerLogReader.Create(complogPath, options: CompilerLogReaderOptions.None);
             foreach (var data in reader.ReadAllCompilerCalls())
             {
-                Assert.NotNull(data.CompilerFilePath);
+                var fileName = Path.GetFileName(complogPath);
+                if (fileName is "windows-console.complog" ||
+                    fileName is "linux-console.complog")
+                {
+                    Assert.Null(data.CompilerFilePath);
+                }
+                else
+                {
+                    Assert.NotNull(data.CompilerFilePath);
+                }
+                
                 Assert.NotEmpty(data.GetArguments());
             }
         }

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -111,6 +111,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
             using var reader = CompilerLogReader.Create(complogPath, options: CompilerLogReaderOptions.None);
             foreach (var data in reader.ReadAllCompilerCalls())
             {
+                Assert.NotNull(data.CompilerFilePath);
                 Assert.NotEmpty(data.GetArguments());
             }
         }

--- a/src/Basic.CompilerLog.Util/CompilerCall.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCall.cs
@@ -34,11 +34,17 @@ public enum CompilerCallKind
     Unknown
 }
 
+/// <summary>
+/// Represents a call to the compiler. The file paths and arguments provided here are correct 
+/// for the machine on which the compiler was run. They cannot be relied on to be correct on 
+/// machines where a compiler log is rehydrated.
+/// </summary>
 public sealed class CompilerCall
 {
     private readonly Lazy<string[]> _lazyArguments;
     private readonly Lazy<CommandLineArguments> _lazyParsedArgumets;
 
+    public string? CompilerFilePath { get; }
     public string ProjectFilePath { get; }
     public CompilerCallKind Kind { get; }
     public string? TargetFramework { get; }
@@ -50,6 +56,7 @@ public sealed class CompilerCall
     public string ProjectDirectory => Path.GetDirectoryName(ProjectFilePath)!;
 
     internal CompilerCall(
+        string? compilerFilePath,
         string projectFilePath,
         CompilerCallKind kind,
         string? targetFramework,
@@ -57,6 +64,7 @@ public sealed class CompilerCall
         Lazy<string[]> arguments,
         int? index)
     {
+        CompilerFilePath = compilerFilePath;
         ProjectFilePath = projectFilePath;
         Kind = kind;
         TargetFramework = targetFramework;

--- a/src/Basic.CompilerLog.Util/CompilerCall.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCall.cs
@@ -42,7 +42,7 @@ public enum CompilerCallKind
 public sealed class CompilerCall
 {
     private readonly Lazy<string[]> _lazyArguments;
-    private readonly Lazy<CommandLineArguments> _lazyParsedArgumets;
+    private readonly Lazy<CommandLineArguments> _lazyParsedArguments;
 
     public string? CompilerFilePath { get; }
     public string ProjectFilePath { get; }
@@ -71,7 +71,7 @@ public sealed class CompilerCall
         IsCSharp = isCSharp;
         Index = index;
         _lazyArguments = arguments;
-        _lazyParsedArgumets = new Lazy<CommandLineArguments>(ParseArgumentsCore);
+        _lazyParsedArguments = new Lazy<CommandLineArguments>(ParseArgumentsCore);
     }
 
     public string GetDiagnosticName() 
@@ -89,7 +89,7 @@ public sealed class CompilerCall
 
     public string[] GetArguments() => _lazyArguments.Value;
 
-    internal CommandLineArguments ParseArguments() => _lazyParsedArgumets.Value;
+    internal CommandLineArguments ParseArguments() => _lazyParsedArguments.Value;
 
     private CommandLineArguments ParseArgumentsCore()
     {

--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -73,6 +73,7 @@ internal sealed class CompilerLogBuilder : IDisposable
             var commandLineArguments = compilerCall.ParseArguments();
             var infoPack = new CompilationInfoPack()
             {
+                CompilerFilePath = compilerCall.CompilerFilePath,
                 ProjectFilePath = compilerCall.ProjectFilePath,
                 IsCSharp = compilerCall.IsCSharp,
                 TargetFramework = compilerCall.TargetFramework,

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -141,6 +141,7 @@ public sealed class CompilerLogReader : IDisposable
     private CompilerCall ReadCompilerCallCore(int index, CompilationInfoPack pack)
     {
         return new CompilerCall(
+            NormalizePath(pack.CompilerFilePath),
             NormalizePath(pack.ProjectFilePath),
             pack.CompilerCallKind,
             pack.TargetFramework,

--- a/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
@@ -98,12 +98,14 @@ public static class CompilerLogUtil
         {
             if (predicate(compilerInvocation))
             {
-                if (builder.Add(compilerInvocation))
+                try
                 {
+                    builder.Add(compilerInvocation);
                     included.Add(compilerInvocation);
                 }
-                else
+                catch (Exception ex)
                 {
+                    diagnostics.Add($"Error adding {compilerInvocation.ProjectFilePath}: {ex.Message}");
                     success = false;
                 }
             }

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -225,6 +225,8 @@ public class CompilationInfoPack
     public string ParseOptionsHash { get; set; }
     [Key(8)]
     public string CompilationOptionsHash { get; set; }
+    [Key(9)]
+    public string? CompilerFilePath { get; set; }
 }
 
 [MessagePackObject]

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -227,6 +227,8 @@ public class CompilationInfoPack
     public string CompilationOptionsHash { get; set; }
     [Key(9)]
     public string? CompilerFilePath { get; set; }
+    [Key(10)]
+    public string? CompilerAssemblyName { get; set; }
 }
 
 [MessagePackObject]

--- a/src/Basic.CompilerLog/FilterOptionSet.cs
+++ b/src/Basic.CompilerLog/FilterOptionSet.cs
@@ -33,7 +33,6 @@ internal sealed class FilterOptionSet : OptionSet
     internal FilterOptionSet(bool analyzers = false)
     {
         Add("include", "include all compilation kinds", i => { if (i is not null) IncludeAllKinds = true; });
-        Add("targetframework=", "", TargetFrameworks.Add, hidden: true);
         Add("f|framework=", "include only compilations for the target framework (allows multiple)", TargetFrameworks.Add);
         Add("p|project=", "include only compilations for the given project (allows multiple)", ProjectNames.Add);
         Add("n|projectName=", "include only compilations for the project", ProjectNames.Add, hidden: true);

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -150,7 +150,11 @@ int RunAnalyzers(IEnumerable<string> args)
 
 int RunPrint(IEnumerable<string> args)
 {
-    var options = new FilterOptionSet();
+    var compilers = false;
+    var options = new FilterOptionSet()
+    {
+        { "c|compilers", "include compiler summary", c => compilers = c is not null },
+    };
 
     try
     {
@@ -165,9 +169,20 @@ int RunPrint(IEnumerable<string> args)
         using var reader = GetCompilerLogReader(compilerLogStream, leaveOpen: true);
         var compilerCalls = reader.ReadAllCompilerCalls(options.FilterCompilerCalls);
 
+        WriteLine("Projects");
         foreach (var compilerCall in compilerCalls)
         {
             WriteLine(compilerCall.GetDiagnosticName());
+        }
+
+        if (compilers)
+        {
+            WriteLine("Compilers");
+            foreach (var tuple in reader.ReadAllCompilerAssemblies())
+            {
+                WriteLine(tuple.CompilerFilePath);
+                WriteLine(tuple.AssemblyName.ToString());
+            }
         }
 
         return ExitSuccess;

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -17,9 +17,9 @@ using TraceReloggerLib;
 
 #pragma warning disable 8321
 
-PrintGeneratedFiles();
+// PrintGeneratedFiles();
 
-//  var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
+var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
 // var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.complog";
 // var filePath = @"C:\Users\jaredpar\code\vs-threading\msbuild.binlog";
 // var filePath = @"c:\users\jaredpar\temp\Build.complog";
@@ -38,7 +38,8 @@ PrintGeneratedFiles();
 
 // Profile();
 
-ExportScratch();
+PrintCompilers(filePath);
+// ExportScratch();
 // await WorkspaceScratch();
 // RoslynScratch();
 // Sarif();
@@ -87,6 +88,16 @@ foreach (var analyzer in analyzers.AnalyzerReferences)
     _ = analyzer.GetGeneratorsForAllLanguages();
 }
 */
+
+void PrintCompilers(string filePath)
+{
+    using var reader = CompilerLogReader.Create(filePath);
+    foreach (var info in reader.ReadAllCompilerAssemblies())
+    {
+        Console.WriteLine(info.CompilerFilePath);
+        Console.WriteLine(info.AssemblyName);
+    }
+}
 
 static void Test(ITypeSymbol symbol)
 {


### PR DESCRIPTION
This stores the compiler used to build the binaries in the complog. 

`complog replay` will now warn when the compiler being used is older than the one the complog was built against

closes #83