### PR TITLE
Using the None host with binary logs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,5 +21,6 @@
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
   </ItemGroup>
 </Project>

--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -30,6 +30,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.Combinatorial" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
@@ -36,7 +36,7 @@ public sealed class BasicAnalyzerHostTests
     [Fact]
     public void NoneDispose()
     {
-        var host = new BasicAnalyzerHostNone(readGeneratedFiles: true, ImmutableArray<(SourceText, string)>.Empty);
+        var host = new BasicAnalyzerHostNone(ImmutableArray<(SourceText, string)>.Empty);
         host.Dispose();
         Assert.Throws<ObjectDisposedException>(() => { _ = host.AnalyzerReferences; });
     }
@@ -44,9 +44,18 @@ public sealed class BasicAnalyzerHostTests
     [Fact]
     public void NoneProps()
     {
-        var host = new BasicAnalyzerHostNone(readGeneratedFiles: true, ImmutableArray<(SourceText, string)>.Empty);
+        var host = new BasicAnalyzerHostNone(ImmutableArray<(SourceText, string)>.Empty);
         host.Dispose();
         Assert.Equal(BasicAnalyzerKind.None, host.Kind);
         Assert.Empty(host.GeneratedSourceTexts);
+    }
+
+    [Fact]
+    public void Error()
+    {
+        var message = "my error message";
+        var host = new BasicAnalyzerHostNone(message);
+        var diagnostic = host.GetDiagnostics().Single();
+        Assert.Contains(message, diagnostic.GetMessage());
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
@@ -132,4 +132,20 @@ public sealed class BinaryLogReaderTests : TestBase
         var emitResult = compilationData.EmitToMemory();
         Assert.True(emitResult.Success);
     }
+
+    [Fact]
+    public void ReadDeletedPdb()
+    {
+        var dir = Root.NewDirectory();
+        RunDotNet($"new console --name example --output .", dir);
+        RunDotNet("build -bl -nr:false", dir);
+
+        // Delete the PDB
+        Directory.EnumerateFiles(dir, "*.pdb", SearchOption.AllDirectories).ForEach(File.Delete);
+
+        using var reader = BinaryLogReader.Create(Path.Combine(dir, "msbuild.binlog"), BasicAnalyzerKind.None);
+        var data = reader.ReadAllCompilationData().Single();
+        var diagnostic = data.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error).Single();
+        Assert.Contains("Can't find portable pdb file for", diagnostic.GetMessage());
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
@@ -120,4 +120,16 @@ public sealed class BinaryLogReaderTests : TestBase
         var compilationData = reader.ReadCompilationData(compilerCall);
         Assert.Equal(basicAnalyzerKind, compilationData.BasicAnalyzerHost.Kind);
     }
+
+    [Theory]
+    [CombinatorialData]
+    public void GetCompilationSimple(BasicAnalyzerKind basicAnalyzerKind)
+    {
+        using var reader = BinaryLogReader.Create(Fixture.Console.Value.BinaryLogPath!, basicAnalyzerKind);
+        var compilerCall = reader.ReadAllCompilerCalls().First();
+        var compilationData = reader.ReadCompilationData(compilerCall);
+        Assert.NotNull(compilationData);
+        var emitResult = compilationData.EmitToMemory();
+        Assert.True(emitResult.Success);
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerCallReaderUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerCallReaderUtilTests.cs
@@ -18,13 +18,14 @@ public sealed class CompilerCallReaderUtilTests : TestBase
     [Fact]
     public void CreateBadExtension()
     {
-        Assert.Throws<ArgumentException>(() => CompilerCallReaderUtil.Get("file.bad"));
+        Assert.Throws<ArgumentException>(() => CompilerCallReaderUtil.Create("file.bad"));
     }
 
-    [Fact]
-    public void GetBadArguments()
+    [Theory]
+    [CombinatorialData]
+    public void GetAllAnalyzerKinds(BasicAnalyzerKind basicAnalyzerKind)
     {
-        var binlogPath = Fixture.Console.Value.BinaryLogPath!;
-        Assert.Throws<ArgumentException>(() => CompilerCallReaderUtil.Get(binlogPath, BasicAnalyzerKind.None));
+        using var reader = CompilerCallReaderUtil.Create(Fixture.Console.Value.CompilerLogPath!, basicAnalyzerKind);
+        Assert.Equal(basicAnalyzerKind, reader.BasicAnalyzerKind);
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -357,7 +357,7 @@ public sealed class CompilerLogReaderTests : TestBase
 
         using var reader = CompilerLogReader.Create(Path.Combine(RootDirectory, "msbuild.binlog"), BasicAnalyzerKind.None);
         var rawData = reader.ReadRawCompilationData(0).Item2;
-        Assert.False(rawData.ReadGeneratedFiles);
+        Assert.False(rawData.HasAllGeneratedFileContent);
         var data = reader.ReadCompilationData(0);
         var compilation = data.GetCompilationAfterGenerators(out var diagnostics);
         Assert.Single(diagnostics);

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogUtilTests.cs
@@ -18,6 +18,6 @@ public sealed class CompilerLogUtilTests : TestBase
     [Fact]
     public void CreateBadExtension()
     {
-        Assert.Throws<ArgumentException>(() => CompilerCallReaderUtil.Get("file.bad"));
+        Assert.Throws<ArgumentException>(() => CompilerCallReaderUtil.Create("file.bad"));
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -66,9 +66,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
     }
 
     [Theory]
-    [InlineData(BasicAnalyzerKind.None)]
-    [InlineData(BasicAnalyzerKind.InMemory)]
-    [InlineData(BasicAnalyzerKind.OnDisk)]
+    [CombinatorialData]
     public async Task EmitToMemory(BasicAnalyzerKind basicAnalyzerKind)
     {
         TestOutputHelper.WriteLine($"BasicAnalyzerKind: {basicAnalyzerKind}");
@@ -77,7 +75,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
         {
             count++;
             TestOutputHelper.WriteLine(logPath);
-            using var reader = CompilerCallReaderUtil.GetOrCreate(logPath, basicAnalyzerKind);
+            using var reader = CompilerCallReaderUtil.Create(logPath, basicAnalyzerKind);
             foreach (var data in reader.ReadAllCompilationData())
             {
                 TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -58,7 +58,7 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         BasicAnalyzerKind? basicAnalyzerKind = null,
         LogReaderState? state = null)
     {
-        var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var stream = RoslynUtil.OpenBuildFileForRead(filePath);
         return Create(stream, basicAnalyzerKind, state: state, leaveOpen: false);
     }
 
@@ -282,7 +282,7 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
 
     void IBasicAnalyzerHostDataProvider.CopyAssemblyBytes(RawAnalyzerData data, Stream stream)
     {
-        using var fileStream = new FileStream(data.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var fileStream = RoslynUtil.OpenBuildFileForRead(data.FilePath);
         fileStream.CopyTo(stream);
     }
 

--- a/src/Basic.CompilerLog.Util/CompilerCallReaderUtil.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCallReaderUtil.cs
@@ -5,7 +5,7 @@ public static class CompilerCallReaderUtil
     /// <summary>
     /// Create an <see cref="ICompilerCallReader"/> directly over the provided file path
     /// </summary>
-    public static ICompilerCallReader Get(string filePath, BasicAnalyzerKind? basicAnalyzerKind = null, LogReaderState? logReaderState = null)
+    public static ICompilerCallReader Create(string filePath, BasicAnalyzerKind? basicAnalyzerKind = null, LogReaderState? logReaderState = null)
     {
         var ext = Path.GetExtension(filePath);
         if (ext is ".binlog")
@@ -19,25 +19,5 @@ public static class CompilerCallReaderUtil
         }
 
         throw new ArgumentException($"Unrecognized extension: {ext}");
-    }
-
-    /// <summary>
-    /// Get or create an <see cref="ICompilerCallReader"/> over the provided file path. The implementation
-    /// may convert binary logs to compiler logs if the provided arguments aren't compatible with 
-    /// a binary log. For example if <see cref="BasicAnalyzerKind.None"/> is provided
-    /// </summary>
-    public static ICompilerCallReader GetOrCreate(string filePath, BasicAnalyzerKind? basicAnalyzerKind = null, LogReaderState? logReaderState = null)
-    {
-        var ext = Path.GetExtension(filePath);
-        if (ext is ".binlog")
-        {
-            if (basicAnalyzerKind is BasicAnalyzerKind.None)
-            {
-                var stream = CompilerLogUtil.GetOrCreateCompilerLogStream(filePath);
-                return CompilerLogReader.Create(stream, basicAnalyzerKind, logReaderState, leaveOpen: false);
-            }
-        }
-
-        return Get(filePath, basicAnalyzerKind, logReaderState);
     }
 }

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
@@ -15,7 +15,7 @@ internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
         new DiagnosticDescriptor(
             "BCLA0001",
             "Cannot read generated files",
-            "Generated files could not be read when compiler log was created",
+            "Error reading generated files: {0}",
             "BasicCompilerLog",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
@@ -24,17 +24,19 @@ internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
     internal ImmutableArray<(SourceText SourceText, string Path)> GeneratedSourceTexts { get; }
     protected override ImmutableArray<AnalyzerReference> AnalyzerReferencesCore { get; }
 
-    internal BasicAnalyzerHostNone(bool readGeneratedFiles, ImmutableArray<(SourceText SourceText, string Path)> generatedSourceTexts)
+    internal BasicAnalyzerHostNone(ImmutableArray<(SourceText SourceText, string Path)> generatedSourceTexts)
         : base(BasicAnalyzerKind.None)
     {
-        ReadGeneratedFiles = readGeneratedFiles;
         GeneratedSourceTexts = generatedSourceTexts;
         AnalyzerReferencesCore = ImmutableArray<AnalyzerReference>.Empty;
+    }
 
-        if (!ReadGeneratedFiles)
-        {
-            AddDiagnostic(Diagnostic.Create(CannotReadGeneratedFiles, Location.None));
-        }
+    internal BasicAnalyzerHostNone(string errorMessage)
+        : base(BasicAnalyzerKind.None)
+    {
+        GeneratedSourceTexts = ImmutableArray<(SourceText SourceText, string Path)>.Empty;
+        AnalyzerReferencesCore = ImmutableArray<AnalyzerReference>.Empty;
+        AddDiagnostic(Diagnostic.Create(CannotReadGeneratedFiles, Location.None, errorMessage));
     }
 
     protected override void DisposeCore()

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
@@ -17,10 +17,9 @@ internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
             "Cannot read generated files",
             "Error reading generated files: {0}",
             "BasicCompilerLog",
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-    internal bool ReadGeneratedFiles { get; }
     internal ImmutableArray<(SourceText SourceText, string Path)> GeneratedSourceTexts { get; }
     protected override ImmutableArray<AnalyzerReference> AnalyzerReferencesCore { get; }
 

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -116,7 +116,7 @@ internal sealed class RawCompilationData
     /// for example happens on a compilation where there are no analyzers (successfully 
     /// read zero files)
     /// </summary>
-    internal bool ReadGeneratedFiles { get; }
+    internal bool HasAllGeneratedFileContent { get; }
 
     internal RawCompilationData(
         int index, 
@@ -130,7 +130,7 @@ internal sealed class RawCompilationData
         List<RawContent> contents,
         List<RawResourceData> resources,
         bool isCSharp,
-        bool readGeneratedFiles)
+        bool hasAllGeneratedFileContent)
     {
         Index = index;
         CompilationName = compilationName;
@@ -143,6 +143,6 @@ internal sealed class RawCompilationData
         Contents = contents;
         Resources = resources;
         IsCSharp = isCSharp;
-        ReadGeneratedFiles = readGeneratedFiles;
+        HasAllGeneratedFileContent = hasAllGeneratedFileContent;
     }
 }

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -248,4 +248,6 @@ public class CompilationDataPack
     public bool IncludesGeneratedText { get; set; }
     [Key(6)]
     public SourceHashAlgorithm ChecksumAlgorithm { get; set; }
+    [Key(7)]
+    public bool? HasGeneratedFilesInPdb { get; set; }
 }

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -550,7 +550,7 @@ Stream GetOrCreateCompilerLogStream(List<string> extra)
 ICompilerCallReader GetCompilerCallReader(List<string> extra, BasicAnalyzerKind? basicAnalyzerKind = null, bool checkVersion = false)
 {
     var logFilePath = GetLogFilePath(extra);
-    var reader = CompilerCallReaderUtil.GetOrCreate(logFilePath, basicAnalyzerKind);
+    var reader = CompilerCallReaderUtil.Create(logFilePath, basicAnalyzerKind);
     OnCompilerCallReader(reader);
     if (reader is CompilerLogReader compilerLogReader)
     {


### PR DESCRIPTION
Before this change using the None host with a binary log required round tripping to a compiler log first. Now it can just be done directly on a binary log. 