### PR TITLE
Add analyzer assembly info printing

### DIFF
--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -352,7 +352,12 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         var list = new List<ReferenceData>(capacity: count);
         foreach (var filePath in filePaths)
         {
-            var data = new ReferenceData(filePath, RoslynUtil.GetMvid(filePath), File.ReadAllBytes(filePath));
+            var data = new ReferenceData(
+                filePath,
+                RoslynUtil.GetMvid(filePath),
+                RoslynUtil.ReadAssemblyName(filePath),
+                RoslynUtil.ReadAssemblyInformationalVersion(filePath),
+                File.ReadAllBytes(filePath));
             list.Add(data);
         }
         return list;
@@ -363,7 +368,11 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         var list = new List<RawAnalyzerData>(args.AnalyzerReferences.Length);
         foreach (var analyzer in args.AnalyzerReferences)
         {
-            var data = new RawAnalyzerData(RoslynUtil.GetMvid(analyzer.FilePath), analyzer.FilePath);
+            var data = new RawAnalyzerData(
+                RoslynUtil.GetMvid(analyzer.FilePath),
+                analyzer.FilePath,
+                RoslynUtil.ReadAssemblyName(analyzer.FilePath),
+                RoslynUtil.ReadAssemblyInformationalVersion(analyzer.FilePath));
             list.Add(data);
         }
         return list;

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -174,11 +174,11 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
 
         var references = dataPack
             .References
-            .Select(x => new RawReferenceData(x.Mvid, x.Aliases, x.EmbedInteropTypes, NormalizePath(x.FilePath)))
+            .Select(x => new RawReferenceData(x.Mvid, x.Aliases, x.EmbedInteropTypes, NormalizePath(x.FilePath), x.AssemblyName, x.AssemblyInformationalVersion))
             .ToList();
         var analyzers = dataPack
             .Analyzers
-            .Select(x => new RawAnalyzerData(x.Mvid, NormalizePath(x.FilePath)))
+            .Select(x => new RawAnalyzerData(x.Mvid, NormalizePath(x.FilePath), x.AssemblyName, x.AssemblyInformationalVersion))
             .ToList();
         var contents = dataPack
             .ContentList
@@ -491,7 +491,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
             var filePath = referenceData.FilePath is string fp
                 ? fp
                 : PathNormalizationUtil.RootFileName(GetMetadataReferenceFileName(referenceData.Mvid));
-            var data = new ReferenceData(filePath, referenceData.Mvid, GetAssemblyBytes(referenceData.Mvid));
+            var data = new ReferenceData(filePath, referenceData.Mvid, referenceData.AssemblyName, referenceData.AssemblyInformationalVersion, GetAssemblyBytes(referenceData.Mvid));
             list.Add(data);
         }
 
@@ -505,7 +505,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         var list = new List<ReferenceData>(rawCompilationData.Analyzers.Count);
         foreach (var analyzerData in rawCompilationData.Analyzers)
         {
-            var data = new ReferenceData(analyzerData.FilePath, analyzerData.Mvid, GetAssemblyBytes(analyzerData.Mvid));
+            var data = new ReferenceData(analyzerData.FilePath, analyzerData.Mvid, analyzerData.AssemblyName, analyzerData.AssemblyInformationalVersion, GetAssemblyBytes(analyzerData.Mvid));
             list.Add(data);
         }
 

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -37,13 +37,17 @@ internal readonly struct RawAnalyzerData
 {
     internal readonly Guid Mvid;
     internal readonly string FilePath;
+    internal readonly string? AssemblyName;
+    internal readonly string? AssemblyInformationalVersion;
 
     internal string FileName => Path.GetFileName(FilePath);
 
-    internal RawAnalyzerData(Guid mvid, string filePath)
+    internal RawAnalyzerData(Guid mvid, string filePath, string? assemblyName, string? assemblyInformationalVersion)
     {
         Mvid = mvid;
         FilePath = filePath;
+        AssemblyName = assemblyName;
+        AssemblyInformationalVersion = assemblyInformationalVersion;
     }
 }
 
@@ -53,13 +57,17 @@ internal readonly struct RawReferenceData
     internal readonly ImmutableArray<string> Aliases;
     internal readonly bool EmbedInteropTypes;
     internal readonly string? FilePath;
+    internal readonly string? AssemblyName;
+    internal readonly string? AssemblyInformationalVersion;
 
-    internal RawReferenceData(Guid mvid, ImmutableArray<string> aliases, bool embedInteropTypes, string? filePath)
+    internal RawReferenceData(Guid mvid, ImmutableArray<string> aliases, bool embedInteropTypes, string? filePath, string? assemblyName, string? assemblyInformationalVersion)
     {
         Mvid = mvid;
         Aliases = aliases;
         EmbedInteropTypes = embedInteropTypes;
         FilePath = filePath;
+        AssemblyName = assemblyName;
+        AssemblyInformationalVersion = assemblyInformationalVersion;
     }
 }
 
@@ -121,7 +129,7 @@ internal sealed class RawCompilationData
     internal bool HasAllGeneratedFileContent { get; }
 
     internal RawCompilationData(
-        int index, 
+        int index,
         string? compilationName,
         string assemblyFileName,
         string? xmlFilePath,

--- a/src/Basic.CompilerLog.Util/ReferenceData.cs
+++ b/src/Basic.CompilerLog.Util/ReferenceData.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Basic.CompilerLog.Util;
 
-public sealed class ReferenceData(string filePath, Guid mvid, byte[] imageBytes)
+public sealed class ReferenceData(string filePath, Guid mvid, string? assemblyName, string? assemblyInformationalVersion, byte[] imageBytes)
 {
     /// <summary>
     /// The file path for the given reference.
@@ -14,6 +14,8 @@ public sealed class ReferenceData(string filePath, Guid mvid, byte[] imageBytes)
     /// </remarks>
     public string FilePath { get; } = filePath;
     public Guid Mvid { get; } = mvid;
+    public string? AssemblyName { get; } = assemblyName;
+    public string? AssemblyInformationalVersion { get; } = assemblyInformationalVersion;
     public byte[] ImageBytes { get; } = imageBytes;
 
     public string FileName => Path.GetFileName(FilePath);

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -603,7 +603,7 @@ internal static class RoslynUtil
 
     internal static string? ReadCompilerCommitHash(string assemblyFilePath)
     {
-        return ReadStringAssemblyAttribute(assemblyFilePath, "CommitHash");
+        return ReadStringAssemblyAttribute(assemblyFilePath, "CommitHashAttribute");
     }
 
     internal static string? ReadAssemblyInformationalVersion(string assemblyFilePath)

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -182,6 +182,10 @@ public class ReferencePack
     public ImmutableArray<string> Aliases { get; set; }
     [Key(4)]
     public string? FilePath { get; set; }
+    [Key(5)]
+    public string? AssemblyName { get; set; }
+    [Key(6)]
+    public string? AssemblyInformationalVersion { get; set; }
 }
 
 [MessagePackObject]
@@ -191,6 +195,10 @@ public class AnalyzerPack
     public Guid Mvid { get; set; }
     [Key(1)]
     public string FilePath { get; set; }
+    [Key(2)]
+    public string? AssemblyName { get; set; }
+    [Key(3)]
+    public string? AssemblyInformationalVersion { get; set; }
 }
 
 [MessagePackObject]

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -75,7 +75,7 @@ int RunCreate(IEnumerable<string> args)
         var convertResult = CompilerLogUtil.TryConvertBinaryLog(binlogFilePath, complogFilePath, options.FilterCompilerCalls);
         foreach (var diagnostic in convertResult.Diagnostics)
         {
-           WriteLine(diagnostic);
+            WriteLine(diagnostic);
         }
 
         if (options.ProjectNames.Count > 0)
@@ -109,7 +109,7 @@ int RunCreate(IEnumerable<string> args)
 }
 
 int RunAnalyzers(IEnumerable<string> args)
-{ 
+{
     var options = new FilterOptionSet();
 
     try
@@ -151,9 +151,11 @@ int RunAnalyzers(IEnumerable<string> args)
 int RunPrint(IEnumerable<string> args)
 {
     var compilers = false;
+    var analyzers = false;
     var options = new FilterOptionSet()
     {
         { "c|compilers", "include compiler summary", c => compilers = c is not null },
+        { "a|analyzers", "include analyzer summary", a => analyzers = a is not null },
     };
 
     try
@@ -172,6 +174,18 @@ int RunPrint(IEnumerable<string> args)
         foreach (var compilerCall in compilerCalls)
         {
             WriteLine($"\t{compilerCall.GetDiagnosticName()}");
+
+            if (analyzers)
+            {
+                WriteLine("Analyzers");
+
+                foreach (var analyzer in reader.ReadAllAnalyzerData(compilerCall))
+                {
+                    WriteLine($"\tName: {analyzer.AssemblyName ?? "<null>"}");
+                    WriteLine($"\tInformational Version: {analyzer.AssemblyInformationalVersion ?? "<null>"}");
+                    WriteLine($"\tFile Path: {analyzer.FilePath}");
+                }
+            }
         }
 
         if (compilers)
@@ -721,7 +735,7 @@ string GetLogFilePath(List<string> extra, bool includeCompilerLogs = true)
             throw new OptionException($"Not a valid log file {logFilePath}", "log");
     }
 
-    static string? FindLogFilePath(string baseDirectory, bool includeCompilerLogs = true ) =>
+    static string? FindLogFilePath(string baseDirectory, bool includeCompilerLogs = true) =>
         includeCompilerLogs
             ? FindFirstFileWithPattern(baseDirectory, "*.complog", "*.binlog", "*.sln", "*.csproj", ".vbproj")
             : FindFirstFileWithPattern(baseDirectory, "*.binlog", "*.sln", "*.csproj", ".vbproj");

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -177,13 +177,13 @@ int RunPrint(IEnumerable<string> args)
 
             if (analyzers)
             {
-                WriteLine("Analyzers");
+                WriteLine("\tAnalyzers");
 
                 foreach (var analyzer in reader.ReadAllAnalyzerData(compilerCall))
                 {
-                    WriteLine($"\tName: {analyzer.AssemblyName ?? "<null>"}");
-                    WriteLine($"\tInformational Version: {analyzer.AssemblyInformationalVersion ?? "<null>"}");
-                    WriteLine($"\tFile Path: {analyzer.FilePath}");
+                    WriteLine($"\t\tName: {analyzer.AssemblyName ?? "<null>"}");
+                    WriteLine($"\t\tInformational Version: {analyzer.AssemblyInformationalVersion ?? "<null>"}");
+                    WriteLine($"\t\tFile Path: {analyzer.FilePath}");
                 }
             }
         }


### PR DESCRIPTION
It would be useful to be able to quickly dump detailed information about analyzer versions from complogs, so we can immediately see, for example, what git commit of the razor compiler was used. This adds just that; we look for the assembly name and AssemblyInformationalVersionAttribute for each analyzer and record that information in the log for printing. We also do this for all references, since it goes through the same code path, but no display of that information is currently done.
