### PR TITLE
Cache file reads in BinaryLogReader

### DIFF
--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -16,6 +16,8 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
 {
     private Stream _stream;
     private readonly bool _leaveOpen;
+    private readonly Dictionary<string, ReferenceData> _referenceDataCache = new(PathUtil.Comparer);
+    private readonly Dictionary<string, RawAnalyzerData> _rawAnalyzerDataCache = new(PathUtil.Comparer);
 
     public bool OwnsLogReaderState { get; }
     public LogReaderState LogReaderState { get; }
@@ -352,7 +354,12 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         var list = new List<ReferenceData>(capacity: count);
         foreach (var filePath in filePaths)
         {
-            var data = new ReferenceData(filePath, RoslynUtil.GetMvid(filePath), File.ReadAllBytes(filePath));
+            if (!_referenceDataCache.TryGetValue(filePath, out var data))
+            {
+                data = new ReferenceData(filePath, RoslynUtil.GetMvid(filePath), File.ReadAllBytes(filePath));
+                _referenceDataCache[filePath] = data;
+            }
+
             list.Add(data);
         }
         return list;
@@ -363,7 +370,11 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         var list = new List<RawAnalyzerData>(args.AnalyzerReferences.Length);
         foreach (var analyzer in args.AnalyzerReferences)
         {
-            var data = new RawAnalyzerData(RoslynUtil.GetMvid(analyzer.FilePath), analyzer.FilePath);
+            if (!_rawAnalyzerDataCache.TryGetValue(analyzer.FilePath, out var data))
+            {
+                data = new RawAnalyzerData(RoslynUtil.GetMvid(analyzer.FilePath), analyzer.FilePath);
+                _rawAnalyzerDataCache[analyzer.FilePath] = data;
+            }
             list.Add(data);
         }
         return list;

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -23,6 +23,7 @@ using Scratch;
 using TraceReloggerLib;
 
 #pragma warning disable 8321
+CountReferences();
 
 // PrintGeneratedFiles();
 
@@ -45,7 +46,7 @@ using TraceReloggerLib;
 
 // Profile();
 
-DarkArtOfBuild();
+// DarkArtOfBuild();
 // ReadAttribute();
 // ExportScratch();
 // await WorkspaceScratch();
@@ -96,6 +97,28 @@ foreach (var analyzer in analyzers.AnalyzerReferences)
     _ = analyzer.GetGeneratorsForAllLanguages();
 }
 */
+
+void CountReferences()
+{
+    var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.binlog";
+    var reader = BinaryLogReader.Create(filePath);
+    var refCount = 0;
+    var satRefCount = 0;
+
+
+    foreach (var cc in reader.ReadAllCompilerCalls())
+    {
+        var references = reader.ReadAllReferenceData(cc);
+        refCount += references.Count;
+        if (cc.Kind == CompilerCallKind.Satellite)
+        {
+            satRefCount += references.Count;
+        }
+    }
+
+    Console.WriteLine($"Reference count: {refCount}");
+    Console.WriteLine($"Satellite Reference count: {satRefCount}");
+}
 
 void DarkArtOfBuild()
 {


### PR DESCRIPTION
A scratch function I wrote to calculate the impact of assembly references in satellite compilations took nearly two minutes to execute. After profiling discovered it was due to repeated reads of the same files on disk. Added a simple cache to handle it.