### PR TITLE
Fix bug around unix paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,8 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/artifacts/bin/Basic.CompilerLog/debug_net8.0/Basic.CompilerLog.dll",
-            "args": ["print", ".\\msbuild.binlog" ],
-            "cwd": "e:\\temp\\console",
+            "args": ["export", "C:\\Users\\jaredpar\\Downloads\\Build1.complog"],
+            "cwd": "C:\\Users\\jaredpar\\Downloads",
             // "cwd": "${workspaceFolder}/src/Basic.CompilerLog",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
         "jaredpar",
         "msbuild",
         "Mvid",
-        "NETCOREAPP",
+        "NET",
         "netstandard",
         "ondisk",
         "Relogger",

--- a/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 
 
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -27,7 +27,7 @@ public sealed class BasicAnalyzerHostTests
     {
         Assert.True(BasicAnalyzerHost.IsSupported(BasicAnalyzerKind.OnDisk));
         Assert.True(BasicAnalyzerHost.IsSupported(BasicAnalyzerKind.None));
-#if NETCOREAPP
+#if NET
         Assert.True(BasicAnalyzerHost.IsSupported(BasicAnalyzerKind.InMemory));
 #else
         Assert.False(BasicAnalyzerHost.IsSupported(BasicAnalyzerKind.InMemory));

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Runtime.InteropServices;
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 using System.Text;

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogUtilTests.cs
@@ -12,7 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 

--- a/src/Basic.CompilerLog.UnitTests/CommonUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CommonUtilTests.cs
@@ -2,7 +2,7 @@
 using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -10,7 +10,7 @@ namespace Basic.CompilerLog.UnitTests;
 
 public sealed class CommonUtilTests
 {
-#if NETCOREAPP
+#if NET
 
     [Fact]
     public void GetAssemlbyLoadContext()

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -24,7 +24,7 @@ public sealed class CompilerLogBuilderTests : TestBase
 
         var compilerCall = BinaryLogUtil.ReadAllCompilerCalls(binlogStream).First(x => x.IsCSharp);
         compilerCall = compilerCall.ChangeArguments(["/sourcelink:does-not-exist.txt"]);
-        Assert.Throws<Exception>(() => builder.Add(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall)));
+        Assert.Throws<Exception>(() => builder.AddFromDisk(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall)));
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public sealed class CompilerLogBuilderTests : TestBase
             isCSharp: true,
             new Lazy<IReadOnlyCollection<string>>(() => args),
             null);
-        builder.Add(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall));
+        builder.AddFromDisk(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall));
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Runtime.InteropServices;
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 using System.Text;
@@ -51,7 +51,7 @@ public sealed class CompilerLogReaderExTests : TestBase
         var diagnostics = new List<string>();
         var stream = new MemoryStream();
         var builder = new CompilerLogBuilder(stream, diagnostics);
-        builder.Add(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall));
+        builder.AddFromDisk(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall));
         builder.Close();
         stream.Position = 0;
         return CompilerLogReader.Create(stream, basicAnalyzerKind, State, leaveOpen: false);

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Runtime.InteropServices;
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 using System.Text;
@@ -249,7 +249,7 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.True(data.BasicAnalyzerHost.IsDisposed);
     }
 
-#if NETCOREAPP
+#if NET
 
     /// <summary>
     /// Ensure that diagnostics are raised when the analyzer can't properly load all of the types

--- a/src/Basic.CompilerLog.UnitTests/ExtensionsTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExtensionsTests.cs
@@ -34,7 +34,7 @@ public sealed class ExtensionsTests : TestBase
         Assert.Equal([42, 13], list);
     }
 
-#if NETCOREAPP
+#if NET
 
     [Fact]
     public void GetFailureString()

--- a/src/Basic.CompilerLog.UnitTests/FilterOptionSetTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/FilterOptionSetTests.cs
@@ -1,4 +1,4 @@
-#if NETCOREAPP
+#if NET
 using Xunit;
 
 namespace Basic.CompilerLog.UnitTests;

--- a/src/Basic.CompilerLog.UnitTests/LogReaderState.cs
+++ b/src/Basic.CompilerLog.UnitTests/LogReaderState.cs
@@ -3,7 +3,7 @@ using Basic.CompilerLog.Util;
 using Xunit;
 using Xunit.Abstractions;
 
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -38,7 +38,7 @@ public class LogReaderStateTests : TestBase
         fileStream.Dispose();
     }
 
-#if NETCOREAPP
+#if NET
     [Fact]
     public void CustomAssemblyLoadContext()
     {

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP
+﻿#if NET
 using Basic.CompilerLog.Util;
 using Basic.CompilerLog.Util.Serialize;
 using MessagePack;

--- a/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using Basic.CompilerLog.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Basic.CompilerLog.UnitTests;
+
+public class StringStreamTests
+{
+    private static readonly Encoding[] Encodings =
+    [
+        Encoding.UTF8,
+        Encoding.UTF32
+    ];
+
+    private void RoundTripByteByByte(string input)
+    {
+        foreach (var encoding in Encodings)
+        {
+            using var inputStream = new StringStream(input, encoding);
+            using var memoryStream = new MemoryStream();
+            while (inputStream.ReadByte() is int b && b != -1)
+            {
+                memoryStream.WriteByte((byte)b);
+            }
+
+            memoryStream.Position = 0;
+            var actual = encoding.GetString(memoryStream.ToArray());
+            Assert.Equal(input, actual);
+        }
+    }
+
+    private void RoundTripCopy(string input)
+    {
+        foreach (var encoding in Encodings)
+        {
+            using var inputStream = new StringStream(input, encoding);
+            using var memoryStream = new MemoryStream();
+            inputStream.CopyTo(memoryStream);
+
+            memoryStream.Position = 0;
+            var actual = encoding.GetString(memoryStream.ToArray());
+            Assert.Equal(input, actual);
+        }
+    }
+
+    private void RoundTripReset(string input)
+    {
+        foreach (var encoding in Encodings)
+        {
+            using var inputStream = new StringStream(input, encoding);
+            using var memoryStream = new MemoryStream();
+            inputStream.Position = 0;
+            memoryStream.Position = 0;
+            inputStream.CopyTo(memoryStream);
+
+            memoryStream.Position = 0;
+            var actual = encoding.GetString(memoryStream.ToArray());
+            Assert.Equal(input, actual);
+        }
+    }
+
+    private void RoundTripAll(string input)
+    {
+        RoundTripByteByByte(input);
+        RoundTripCopy(input);
+        RoundTripReset(input);
+    }
+
+    [Theory]
+    [InlineData("Hello, world!")]
+    [InlineData("")]
+    [InlineData("lets try this value")]
+    public void RoundTrip(string input) => RoundTripAll(input);
+
+    [Fact]
+    public void RoundTripGenerated()
+    {
+        RoundTripAll(new string('a', 1000));
+        RoundTripAll(new string('a', 10_000));
+    }
+}

--- a/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
@@ -67,6 +67,19 @@ public class StringStreamTests
         RoundTripReset(input);
     }
 
+    [Fact]
+    public void Behaviors()
+    {
+        var stream = new StringStream("hello", Encoding.UTF8);
+        Assert.True(stream.CanRead);
+        Assert.False(stream.CanWrite);
+        Assert.Throws<NotSupportedException>(() => stream.CanSeek);
+        Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        Assert.Throws<NotSupportedException>(() => stream.Write(Array.Empty<byte>(), 0, 0));
+        Assert.Throws<NotSupportedException>(() => stream.SetLength(1));
+        stream.Flush(); // no-op
+    }
+
     [Theory]
     [InlineData("Hello, world!")]
     [InlineData("")]
@@ -78,5 +91,15 @@ public class StringStreamTests
     {
         RoundTripAll(new string('a', 1000));
         RoundTripAll(new string('a', 10_000));
+    }
+
+    [Fact]
+    public void ReadEmpty()
+    {
+        var stream = new StringStream("hello world", Encoding.UTF8);
+        Assert.Equal(0, stream.Read(Array.Empty<byte>(), 0, 0));
+#if NET
+        Assert.Equal(0, stream.Read(Array.Empty<byte>().AsSpan()));
+#endif
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Basic.CompilerLog.Util;
+using DotUtils.StreamUtils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -78,6 +79,25 @@ public class StringStreamTests
         Assert.Throws<NotSupportedException>(() => stream.Write(Array.Empty<byte>(), 0, 0));
         Assert.Throws<NotSupportedException>(() => stream.SetLength(1));
         stream.Flush(); // no-op
+    }
+
+    [Fact]
+    public void PositionReset()
+    {
+        var stream = new StringStream("hello", Encoding.UTF8);
+        var bytes1 = stream.ReadToEnd();
+        stream.Position = 0;
+        var bytes2 = stream.ReadToEnd();
+        Assert.Equal(bytes1, bytes2);
+    }
+
+    [Fact]
+    public void PositionSetToMiddle()
+    {
+        var stream = new StringStream("hello", Encoding.UTF8);
+        var bytes1 = stream.ReadToEnd();
+        stream.Position = 0;
+        Assert.Throws<NotSupportedException>(() => stream.Position = 1);
     }
 
     [Theory]

--- a/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
@@ -73,7 +73,7 @@ public class StringStreamTests
         var stream = new StringStream("hello", Encoding.UTF8);
         Assert.True(stream.CanRead);
         Assert.False(stream.CanWrite);
-        Assert.Throws<NotSupportedException>(() => stream.CanSeek);
+        Assert.False(stream.CanSeek);
         Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
         Assert.Throws<NotSupportedException>(() => stream.Write(Array.Empty<byte>(), 0, 0));
         Assert.Throws<NotSupportedException>(() => stream.SetLength(1));

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -96,6 +96,17 @@ public abstract class TestBase : IDisposable
         return reader;
     }
 
+    private protected CompilerLogReader CreateReader(Action<CompilerLogBuilder> action, LogReaderState? state = null)
+    {
+        var stream = new MemoryStream();
+        var diagnostics = new List<string>();
+        var builder = new CompilerLogBuilder(stream, diagnostics);
+        action(builder);
+        builder.Close();
+        stream.Position = 0;
+        return CompilerLogReader.Create(stream, state, leaveOpen: false);
+    }
+
     /// <summary>
     /// Run the build.cmd / .sh generated from an export command
     /// </summary>

--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net472;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>embedded</DebugType>
@@ -10,6 +10,7 @@
     <Packable>true</Packable>
     <NoWarn>$(NoWarn);RS2008;CS1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
+++ b/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
@@ -51,7 +51,7 @@ public abstract class BasicAnalyzerHost : IDisposable
     {
         get
         {
-#if NETCOREAPP
+#if NET
             return BasicAnalyzerKind.InMemory;
 #else
             return BasicAnalyzerKind.OnDisk;
@@ -117,7 +117,7 @@ public abstract class BasicAnalyzerHost : IDisposable
 
     public static bool IsSupported(BasicAnalyzerKind kind)
     {
-#if NETCOREAPP
+#if NET
         return true;
 #else
         return kind is BasicAnalyzerKind.OnDisk or BasicAnalyzerKind.None;

--- a/src/Basic.CompilerLog.Util/CommonUtil.cs
+++ b/src/Basic.CompilerLog.Util/CommonUtil.cs
@@ -7,7 +7,7 @@ using MessagePack;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -24,7 +24,7 @@ internal static class CommonUtil
     internal static string GetAssemblyEntryName(Guid mvid) => $"assembly/{mvid:N}";
     internal static string GetContentEntryName(string contentHash) => $"content/{contentHash}";
 
-#if NETCOREAPP
+#if NET
 
     internal static AssemblyLoadContext GetAssemblyLoadContext(AssemblyLoadContext? context)
     {

--- a/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
@@ -99,7 +99,7 @@ public static class CompilerLogUtil
             try
             {
                 var commandLineArguments = BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall);
-                builder.Add(compilerCall, commandLineArguments);
+                builder.AddFromDisk(compilerCall, commandLineArguments);
                 included.Add(compilerCall);
             }
             catch (Exception ex)

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -33,7 +33,7 @@ internal sealed class BasicAnalyzerHostInMemory : BasicAnalyzerHost
     }
 }
 
-#if NETCOREAPP
+#if NET
 
 internal sealed class InMemoryLoader : AssemblyLoadContext
 {

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostOnDisk.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostOnDisk.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata.Ecma335;
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 using System.Text;
@@ -64,7 +64,7 @@ internal sealed class BasicAnalyzerHostOnDisk : BasicAnalyzerHost
     }
 }
 
-#if NETCOREAPP
+#if NET
 
 internal sealed class OnDiskLoader : AssemblyLoadContext, IAnalyzerAssemblyLoader, IDisposable
 {

--- a/src/Basic.CompilerLog.Util/LogReaderState.cs
+++ b/src/Basic.CompilerLog.Util/LogReaderState.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP
+﻿#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -46,7 +46,7 @@ public sealed class LogReaderState : IDisposable
 
     internal List<BasicAnalyzerHost> BasicAnalyzerHosts { get; } = new();
 
-#if NETCOREAPP
+#if NET
 
     public AssemblyLoadContext CompilerLoadContext { get; }
 
@@ -77,7 +77,7 @@ public sealed class LogReaderState : IDisposable
         BaseDirectory = baseDir ?? Path.Combine(Path.GetTempPath(), "Basic.CompilerLog", Guid.NewGuid().ToString("N"));
         CryptoKeyFileDirectory = Path.Combine(BaseDirectory, "CryptoKeys");
         AnalyzerDirectory = Path.Combine(BaseDirectory, "Analyzers");
-#if NETCOREAPP
+#if NET
         CompilerLoadContext = CommonUtil.GetAssemblyLoadContext(null);
 #endif
         if (cacheAnalyzers)

--- a/src/Basic.CompilerLog.Util/StringStream.cs
+++ b/src/Basic.CompilerLog.Util/StringStream.cs
@@ -1,0 +1,138 @@
+
+using System.Diagnostics;
+using System.Text;
+
+namespace Basic.CompilerLog.Util;
+
+internal sealed class StringStream(string content, Encoding encoding) : Stream
+{
+    private readonly string _content = content;
+    private readonly Encoding _encoding = encoding;
+    private int _contentPosition;
+    private int _bytePosition;
+
+    // These fields come into play when we have to read portions of a character at a time
+    private int _splitCharPosition = -1;
+    private int _splitCharCount;
+    private byte[] _splitCharBuffer = Array.Empty<byte>();
+
+    internal bool InSplitChar => _splitCharPosition >= 0;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position 
+    {
+        get => _bytePosition;
+        set
+        {
+            if (value != 0)
+            {
+                throw new NotSupportedException();
+            }
+
+            _bytePosition = 0;
+            _contentPosition = 0;
+            _splitCharPosition = -1;
+        }
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        ReadCore(buffer.AsSpan(offset, count));
+
+#if NET
+    public override int Read(Span<byte> buffer) =>
+        ReadCore(buffer);
+#endif
+
+    private int ReadCore(Span<byte> buffer)
+    {
+        if (buffer.Length == 0)
+        {
+            return 0;
+        }
+
+        if (_contentPosition >= _content.Length)
+        {
+            return 0;
+        }
+
+        return InSplitChar
+            ? ReadFromSplitChar(buffer)
+            : ReadFromString(buffer);
+    }
+
+    private int ReadFromSplitChar(Span<byte> buffer)
+    {
+        Debug.Assert(InSplitChar);
+        Debug.Assert(buffer.Length > 0);
+        Debug.Assert(_splitCharPosition >= 0);
+        Debug.Assert(_splitCharCount > 0 && _splitCharCount <= _splitCharBuffer.Length);
+
+        int count = Math.Min(_splitCharCount - _splitCharPosition, buffer.Length);
+        _splitCharBuffer.AsSpan(_splitCharPosition, count).CopyTo(buffer);
+        _splitCharPosition += count;
+        if (_splitCharPosition == _splitCharBuffer.Length)
+        {
+            _splitCharPosition = -1;
+            _contentPosition++;
+        }
+
+        return count;
+    }
+
+    private int ReadFromString(Span<byte> buffer)
+    {
+        Debug.Assert(!InSplitChar);
+        Debug.Assert(buffer.Length > 0);
+        Debug.Assert(_contentPosition < _content.Length);
+
+        var charCount = Math.Min(_content.Length - _contentPosition, 512);
+        do
+        {
+            var charSpan = _content.AsSpan(_contentPosition, charCount);
+            var byteCount = _encoding.GetByteCount(charSpan);
+            if (byteCount > buffer.Length)
+            {
+                if (charCount == 1)
+                {
+                    // Buffer isn't big enough to hold a single character. Need to move into a split character 
+                    // mode to handle this case.
+                    if (byteCount > _splitCharBuffer.Length)
+                    {
+                        _splitCharBuffer = new byte[byteCount];
+                    }
+
+                    _splitCharPosition = 0;
+                    _splitCharCount = _encoding.GetBytes(_content.AsSpan(_contentPosition, 1), _splitCharBuffer);
+                    Debug.Assert(_splitCharCount <= _splitCharBuffer.Length);
+
+                    return ReadFromSplitChar(buffer);
+                }
+
+                charCount /= 2;
+                continue;
+            }
+
+            var read = _encoding.GetBytes(charSpan, buffer);
+            Debug.Assert(read == byteCount);
+            _contentPosition += charCount;
+            return read;
+        } while (true);
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => 
+        throw new NotSupportedException();
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+}


### PR DESCRIPTION
Unix paths were accidentally being treated as options when exporting the RSP file. This lead to the RSP file being invalid as it had paths that weren't available the local machine (or even valid paths when crossing between operating systems).

The fix was fairly simple but testing it caused a decent amount of churn in the repository. Had to add APIs to make it possible to build up a compiler log in memory instead of off of disk.