### PR TITLE
Better API for CompilerCall

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerCallTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerCallTests.cs
@@ -9,14 +9,9 @@ public class CompilerCallTests
     [Fact]
     public void GetDiagnosticNameNoTargetFramework()
     {
-        var compilerCall = new CompilerCall(
-            compilerFilePath: null,
-            "test.csproj",
-            CompilerCallKind.Regular,
-            targetFramework: null,
-            isCSharp: true,
-            arguments: new (() => []));
+        var compilerCall = new CompilerCall("test.csproj");
         Assert.Null(compilerCall.TargetFramework);
         Assert.Equal(compilerCall.ProjectFileName, compilerCall.GetDiagnosticName());
+        Assert.Empty(compilerCall.GetArguments());
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -37,13 +37,9 @@ public sealed class CompilerLogBuilderTests : TestBase
         var compilerCall = BinaryLogUtil.ReadAllCompilerCalls(binlogStream).First(x => x.IsCSharp);
         var args = compilerCall.GetArguments();
         compilerCall = new CompilerCall(
-            compilerFilePath: null,
             compilerCall.ProjectFilePath,
-            CompilerCallKind.Regular,
-            compilerCall.TargetFramework,
-            isCSharp: true,
-            new Lazy<IReadOnlyCollection<string>>(() => args),
-            null);
+            targetFramework: compilerCall.TargetFramework,
+            arguments: args.ToArray());
         builder.AddFromDisk(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall));
     }
 

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -268,12 +268,12 @@ public sealed class ExportUtilTests : TestBase
         var reader = CreateReader(builder =>
         {
             var compilerCall = new CompilerCall(
-                compilerFilePath: "app",
                 projectFilePath: "/src/app.csproj",
+                compilerFilePath: "app",
                 CompilerCallKind.Regular,
                 targetFramework: "net5.0",
                 isCSharp: true,
-                arguments: new (() => args));
+                arguments: args);
 
             builder.AddContent(compilerCall, ["Console.WriteLine()"]);
         });

--- a/src/Basic.CompilerLog.UnitTests/Extensions.cs
+++ b/src/Basic.CompilerLog.UnitTests/Extensions.cs
@@ -42,8 +42,8 @@ internal static class Extensions
     internal static CompilerCall WithArguments(this CompilerCall compilerCall, IReadOnlyCollection<string> arguments)
     {
         return new CompilerCall(
-            compilerCall.CompilerFilePath,
             compilerCall.ProjectFilePath,
+            compilerCall.CompilerFilePath,
             compilerCall.Kind,
             compilerCall.TargetFramework,
             compilerCall.IsCSharp,
@@ -55,8 +55,8 @@ internal static class Extensions
     {
         var args = compilerCall.GetArguments();
         return new CompilerCall(
-            compilerCall.CompilerFilePath,
             compilerCall.ProjectFilePath,
+            compilerCall.CompilerFilePath,
             compilerCall.Kind,
             compilerCall.TargetFramework,
             compilerCall.IsCSharp,

--- a/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
@@ -112,8 +112,8 @@ public static class BinaryLogUtil
                 : ParseTaskForCompilerAndArguments(CommandLineArguments, "vbc.exe", "vbc.dll");
 
             return new CompilerCall(
-                compilerFilePath,
                 projectFile,
+                compilerFilePath,
                 kind,
                 targetFramework,
                 isCSharp: IsCSharp,

--- a/src/Basic.CompilerLog.Util/CompilerCall.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCall.cs
@@ -43,8 +43,8 @@ public sealed class CompilerCall
 {
     private readonly Lazy<IReadOnlyCollection<string>> _lazyArguments;
 
-    public string? CompilerFilePath { get; }
     public string ProjectFilePath { get; }
+    public string? CompilerFilePath { get; }
     public CompilerCallKind Kind { get; }
     public string? TargetFramework { get; }
     public bool IsCSharp { get; }
@@ -55,8 +55,8 @@ public sealed class CompilerCall
     public bool IsVisualBasic => !IsCSharp;
 
     internal CompilerCall(
-        string? compilerFilePath,
         string projectFilePath,
+        string? compilerFilePath,
         CompilerCallKind kind,
         string? targetFramework,
         bool isCSharp,
@@ -72,6 +72,25 @@ public sealed class CompilerCall
         _lazyArguments = arguments;
         ProjectFileName = Path.GetFileName(ProjectFilePath);
         ProjectDirectory = Path.GetDirectoryName(ProjectFilePath)!;
+    }
+
+    internal CompilerCall(
+        string projectFilePath,
+        string? compilerFilePath = null,
+        CompilerCallKind kind = CompilerCallKind.Regular,
+        string? targetFramework = null,
+        bool isCSharp = true,
+        string[]? arguments = null,
+        object? ownerState = null) 
+        : this(
+            projectFilePath,
+            compilerFilePath,
+            kind,
+            targetFramework,
+            isCSharp,
+            new Lazy<IReadOnlyCollection<string>>(() => arguments ?? []),
+            ownerState)
+    {
     }
 
     public string GetDiagnosticName() 

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -159,8 +159,8 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
     private CompilerCall ReadCompilerCallCore(int index, CompilationInfoPack pack)
     {
         return new CompilerCall(
-            NormalizePath(pack.CompilerFilePath),
             NormalizePath(pack.ProjectFilePath),
+            NormalizePath(pack.CompilerFilePath),
             pack.CompilerCallKind,
             pack.TargetFramework,
             pack.IsCSharp,


### PR DESCRIPTION
The `CompilerCall` API was hard to create in testing due to the order of arguments and how much it was geared towards efficient loading. This changes the constructor parameter order to be more natural and added an overload that much easier to use from testing.