### PR TITLE
Support for project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Compiler Logs
-===
+# Compiler Logs
 
 [![codecov](https://codecov.io/gh/jaredpar/complog/graph/badge.svg?token=MIM7Y2JZ5G)](https://codecov.io/gh/jaredpar/complog)
 
@@ -70,7 +69,9 @@ When trying to get a compiler log from a build that occurs in a GitHub action yo
 ```
 
 ## Debugging Compiler Logs
+
 ### Running locally
+
 To re-run all of the compilations in a compiler log use the `replay` command
 
 ```cmd
@@ -83,7 +84,8 @@ Microsoft.CodeAnalysis.XunitHook.csproj (net472) ...Success
 Passing the `-export` argument will cause all failed compilations to be exported to the local disk for easy analysis.
 
 ### Debugging in Visual Studio
-To debug a compilation in Visual Studio first export it to disk: 
+
+To debug a compilation in Visual Studio first export it to disk:
 
 ```cmd
 > complog export build.complog

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,16 @@
+ Converting looks like this       
+ 
+        public static PortableExecutableReference EmitToPortableExecutableReference(
+            this Compilation comp,
+            EmitOptions options = null,
+            bool embedInteropTypes = false,
+            ImmutableArray<string> aliases = default,
+            DiagnosticDescription[] expectedWarnings = null)
+        {
+            var image = comp.EmitToArray(options, expectedWarnings: expectedWarnings);
+            if (comp.Options.OutputKind == OutputKind.NetModule)
+            {
+                return ModuleMetadata.CreateFromImage(image).GetReference(display: comp.MakeSourceModuleName());
+            }
+            else
+            {

--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -42,6 +42,9 @@
     <EmbeddedResource Include="Resources\MetadataVersion1\console.complog">
         <LogicalName>MetadataVersion1.console.complog</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MetadataVersion2\console.complog">
+        <LogicalName>MetadataVersion2.console.complog</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\linux-console.complog">
         <LogicalName>linux-console.complog</LogicalName>
     </EmbeddedResource>

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -493,7 +493,7 @@ public sealed class CompilerLogReaderTests : TestBase
             .ReadAllCompilerCalls(cc => cc.ProjectFileName == "util.csproj")
             .Single();
         var consoleCompilerCall = reader
-            .ReadAllCompilerCalls(cc => cc.ProjectFileName == "console.csproj")
+            .ReadAllCompilerCalls(cc => cc.ProjectFileName == "console-with-reference.csproj")
             .Single();
         var count = 0;
         foreach (var rawReferenceData in reader.ReadAllReferenceData(consoleCompilerCall))

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -465,4 +465,23 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.True(data.IsVisualBasic);
         Assert.True(data.CompilerCall.IsVisualBasic);
     }
+
+    [Fact]
+    public void ProjectReferences_Simple()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath);
+        var compilerCall = reader.ReadCompilerCall(0);
+        var arguments = BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall);
+        var (assemblyFilePath, refAssemblyFilePath) = RoslynUtil.GetAssemblyOutputFilePaths(arguments);
+        AssertProjectRef(assemblyFilePath);
+        AssertProjectRef(refAssemblyFilePath);
+
+        void AssertProjectRef(string? filePath)
+        {
+            Assert.NotNull(filePath);
+            var mvid = RoslynUtil.ReadMvid(filePath);
+            Assert.True(reader.TryGetCompilerCallIndex(mvid, out var callIndex));
+            Assert.Equal(reader.GetIndex(compilerCall), callIndex);
+        }
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -484,4 +484,26 @@ public sealed class CompilerLogReaderTests : TestBase
             Assert.Equal(reader.GetIndex(compilerCall), callIndex);
         }
     }
+
+    [Fact]
+    public void ProjectReferences_ReadReference()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleWithReference.Value.CompilerLogPath);
+        var classLibCompilerCall = reader
+            .ReadAllCompilerCalls(cc => cc.ProjectFileName == "util.csproj")
+            .Single();
+        var consoleCompilerCall = reader
+            .ReadAllCompilerCalls(cc => cc.ProjectFileName == "console.csproj")
+            .Single();
+        var count = 0;
+        foreach (var rawReferenceData in reader.ReadAllReferenceData(consoleCompilerCall))
+        {
+            if (reader.TryGetCompilerCallIndex(rawReferenceData.Mvid, out var callIndex))
+            {
+                Assert.Equal(reader.GetIndex(classLibCompilerCall), callIndex);
+                count++;
+            }
+        }
+        Assert.Equal(1, count);
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/FixtureBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/FixtureBase.cs
@@ -30,6 +30,9 @@ public abstract class FixtureBase
         diagnosticBuilder.AppendLine($"Standard Error: {result.StandardError}");
         diagnosticBuilder.AppendLine($"Finished: {(DateTime.UtcNow - start).TotalSeconds:F2}s");
         MessageSink.OnMessage(new DiagnosticMessage(diagnosticBuilder.ToString()));
-        Assert.True(result.Succeeded);
+        if (!result.Succeeded)
+        {
+            Assert.Fail($"Command failed: {diagnosticBuilder.ToString()}");
+        }
     }
 }

--- a/src/Basic.CompilerLog.Util/CommonUtil.cs
+++ b/src/Basic.CompilerLog.Util/CommonUtil.cs
@@ -17,6 +17,7 @@ internal static class CommonUtil
 {
     internal const string MetadataFileName = "metadata.txt";
     internal const string AssemblyInfoFileName = "assemblyinfo.txt";
+    internal const string LogInfoFileName = "loginfo.txt";
     internal static readonly Encoding ContentEncoding = Encoding.UTF8;
     internal static readonly MessagePackSerializerOptions SerializerOptions = MessagePackSerializerOptions.Standard.WithAllowAssemblyVersionMismatch(true);
 

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -305,7 +305,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
     {
         var pack = GetOrReadCompilationInfo(GetIndex(compilerCall));
         var rawCompilationData = ReadRawCompilationData(compilerCall);
-        var referenceList = RenameMetadataReferences(rawCompilationData.References);
+        var referenceList = ReadMetadataReferences(rawCompilationData.References);
         var (emitOptions, rawParseOptions, compilationOptions) = ReadCompilerOptions(pack);
 
         var hashAlgorithm = rawCompilationData.ChecksumAlgorithm;
@@ -548,6 +548,10 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         throw new ArgumentException($"{mvid} is not a valid MVID");
     }
 
+    /// <summary>
+    /// Reads a <see cref="MetadataReference"/> with the given <paramref name="mvid" />. This
+    /// does not include extra metadata properties like alias, embedded interop types, etc ...
+    /// </summary>
     internal MetadataReference ReadMetadataReference(Guid mvid)
     {
         if (_refMap.TryGetValue(mvid, out var metadataReference))
@@ -562,7 +566,11 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         return metadataReference;
     }
 
-    internal MetadataReference RenameMetadataReference(in RawReferenceData data)
+    /// <summary>
+    /// Reads a <see cref="MetadataReference"/> from the given <paramref name="data"/> and applies
+    /// all of the properties like alias, embedded interop types, etc ...
+    /// </summary>
+    internal MetadataReference ReadMetadataReference(in RawReferenceData data)
     {
         var reference = ReadMetadataReference(data.Mvid);
         if (data.EmbedInteropTypes)
@@ -578,12 +586,12 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         return reference;
     }
 
-    internal List<MetadataReference> RenameMetadataReferences(List<RawReferenceData> referenceDataList)
+    internal List<MetadataReference> ReadMetadataReferences(List<RawReferenceData> referenceDataList)
     {
         var list = new List<MetadataReference>(capacity: referenceDataList.Count);
         foreach (var referenceData in referenceDataList)
         {
-            list.Add(RenameMetadataReference(referenceData));
+            list.Add(ReadMetadataReference(referenceData));
         }
         return list;
     }

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -42,6 +42,12 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
     private readonly Dictionary<int, CompilationInfoPack> _compilationInfoMap = new();
 
     /// <summary>
+    /// This stores the map between an assembly MVID and the <see cref="CompilerCall"/> that 
+    /// produced it. This is useful for building up items like a project reference map.
+    /// </summary>
+    private readonly Dictionary<Guid, int> _mvidToCompilerCallIndexMap = new();
+
+    /// <summary>
     /// Is this reader responsible for disposing the <see cref="LogReaderState"/> instance
     /// </summary>
     public bool OwnsLogReaderState { get; }
@@ -63,7 +69,6 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         OwnsLogReaderState = state is null;
         LogReaderState = state ?? new LogReaderState();
         Metadata = metadata;
-        ReadAssemblyInfo();
 
         PathNormalizationUtil = (Metadata.IsWindows, RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) switch
         {
@@ -72,6 +77,15 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
             (false, true) => PathNormalizationUtil.UnixToWindows,
             (false, false) => PathNormalizationUtil.Empty,
         };
+
+        if (metadata.MetadataVersion == 2)
+        {
+            ReadAssemblyInfo();
+        }
+        else
+        {
+            ReadLogInfo();
+        }
 
         void ReadAssemblyInfo()
         {
@@ -82,6 +96,21 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
                 var mvid = Guid.Parse(items[1]);
                 var assemblyName = new AssemblyName(items[2]);
                 _mvidToRefInfoMap[mvid] = (items[0], assemblyName);
+            }
+        }
+
+        void ReadLogInfo()
+        {
+            using var reader = Polyfill.NewStreamReader(ZipArchive.OpenEntryOrThrow(LogInfoFileName), ContentEncoding, leaveOpen: false);
+            var hash = reader.ReadLine();
+            var pack = GetContentPack<LogInfoPack>(hash!);
+            foreach (var kvp in pack.MvidToReferenceInfoMap)
+            {
+                _mvidToRefInfoMap[kvp.Key] = (kvp.Value.FileName, new AssemblyName(kvp.Value.AssemblyName));
+            }
+            foreach (var tuple in pack.CompilerCallMvidList)
+            {
+                _mvidToCompilerCallIndexMap[tuple.Mvid] = tuple.CompilerCallIndex;
             }
         }
     }
@@ -98,7 +127,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
             var metadata = ReadMetadata();
             return metadata.MetadataVersion switch {
                 1 => throw new CompilerLogException("Version 1 compiler logs are no longer supported"),
-                2 => new CompilerLogReader(zipArchive, metadata, basicAnalyzerKind, state),
+                2 or 3 => new CompilerLogReader(zipArchive, metadata, basicAnalyzerKind, state),
                 _ => throw new CompilerLogException($"Version {metadata.MetadataVersion} is higher than the max supported version {Metadata.LatestMetadataVersion}"),
             };
 
@@ -652,6 +681,9 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         using var stream = ZipArchive.OpenEntryOrThrow(GetAssemblyEntryName(mvid));
         stream.CopyTo(destination);
     }
+
+    internal bool TryGetCompilerCallIndex(Guid mvid, out int compilerCallIndex) =>
+        _mvidToCompilerCallIndexMap.TryGetValue(mvid, out compilerCallIndex);
 
     [return: NotNullIfNotNull("path")]
     private string? NormalizePath(string? path) => PathNormalizationUtil.NormalizePath(path);

--- a/src/Basic.CompilerLog.Util/Metadata.cs
+++ b/src/Basic.CompilerLog.Util/Metadata.cs
@@ -9,7 +9,7 @@ namespace Basic.CompilerLog.Util;
 
 internal sealed class Metadata
 {
-    internal static readonly int LatestMetadataVersion = 2;
+    internal static readonly int LatestMetadataVersion = 3;
 
     internal int MetadataVersion { get; }
     internal int Count { get; }

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -301,6 +301,24 @@ internal static class RoslynUtil
         };
     }
 
+    internal static (string? AssemblyFilePath, string? RefAssemblyFilePath) GetAssemblyOutputFilePaths(CommandLineArguments arguments)
+    {
+        var assemblyFileName = RoslynUtil.GetAssemblyFileName(arguments);
+        string? assemblyFilePath = null;
+        if (arguments.OutputDirectory is { } outputDirectory)
+        {
+            assemblyFilePath = Path.Combine(outputDirectory, assemblyFileName);
+        }
+
+        string? refAssemblyFilePath = null;
+        if (arguments.OutputRefFilePath is { })
+        {
+            refAssemblyFilePath = arguments.OutputRefFilePath;
+        }
+
+        return (assemblyFilePath, refAssemblyFilePath);
+    }
+
     /// <summary>
     /// This checks determines if this compilation should have the files from source generators
     /// embedded in the PDB. This does not look at anything on disk, it makes a determination

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -214,6 +214,10 @@ public class ResourcePack
     public bool IsPublic { get; set; }
 }
 
+/// <summary>
+/// This is used to serialize information around the <see cref="CompilerCall"/>. Information 
+/// that isn't necessary for that type should go to <see cref="CompilationDataPack"/> instead.
+/// </summary>
 [MessagePackObject]
 public class CompilationInfoPack
 {
@@ -262,4 +266,16 @@ public class CompilationDataPack
     public SourceHashAlgorithm ChecksumAlgorithm { get; set; }
     [Key(7)]
     public bool? HasGeneratedFilesInPdb { get; set; }
+}
+
+/// <summary>
+/// This stores information that is relevant to all compiler calls.
+/// </summary>
+[MessagePackObject]
+public class LogInfoPack
+{
+    [Key(0)]
+    public List<(int CompilerCallIndex, bool IsRefAssembly, Guid Mvid)> CompilerCallMvidList { get; set; }
+    [Key(1)]
+    public Dictionary<Guid, (string FileName, string AssemblyName)> MvidToReferenceInfoMap { get; set; }
 }

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -13,13 +13,13 @@ namespace Basic.CompilerLog.Util;
 
 public sealed class SolutionReader : IDisposable
 {
-    private readonly ImmutableArray<(CompilerCall CompilerCall, ProjectId ProjectId)> _projectDataList;
+    private readonly SortedDictionary<int, (CompilerCall CompilerCall, ProjectId ProjectId)> _indexToProjectDataMap;
 
     internal CompilerLogReader Reader { get; }
     internal VersionStamp VersionStamp { get; }
     internal SolutionId SolutionId { get; } = SolutionId.CreateNewId();
 
-    public int ProjectCount => _projectDataList.Length;
+    public int ProjectCount => _indexToProjectDataMap.Count;
 
     internal SolutionReader(CompilerLogReader reader, Func<CompilerCall, bool>? predicate = null, VersionStamp? versionStamp = null)
     {
@@ -27,17 +27,18 @@ public sealed class SolutionReader : IDisposable
         VersionStamp = versionStamp ?? VersionStamp.Default;
 
         predicate ??= static c => c.Kind == CompilerCallKind.Regular;
-        var builder = ImmutableArray.CreateBuilder<(CompilerCall, ProjectId)>();
+        var map = new SortedDictionary<int, (CompilerCall, ProjectId)>();
         for (int i = 0; i < reader.Count; i++)
         {
             var call = reader.ReadCompilerCall(i);
             if (predicate(call))
             {
                 var projectId = ProjectId.CreateNewId(debugName: i.ToString());
-                builder.Add((call, projectId));
+                map[i] = (call, projectId);
             }
         }
-        _projectDataList = builder.ToImmutableArray();
+
+        _indexToProjectDataMap = map;
     }
 
     public void Dispose()
@@ -56,18 +57,17 @@ public sealed class SolutionReader : IDisposable
 
     public SolutionInfo ReadSolutionInfo()
     {
-        var projectInfoList = new List<ProjectInfo>();
-        for (var i = 0; i < ProjectCount; i++)
+        var projectInfoList = new List<ProjectInfo>(capacity: ProjectCount);
+        foreach (var kvp in _indexToProjectDataMap)
         {
-            projectInfoList.Add(ReadProjectInfo(i));
+            projectInfoList.Add(ReadProjectInfo(kvp.Value.CompilerCall, kvp.Value.ProjectId));
         }
 
         return SolutionInfo.Create(SolutionId, VersionStamp, projects: projectInfoList);
     }
 
-    public ProjectInfo ReadProjectInfo(int index)
+    private ProjectInfo ReadProjectInfo(CompilerCall compilerCall, ProjectId projectId)
     {
-        var (compilerCall, projectId) = _projectDataList[index];
         var rawCompilationData = Reader.ReadRawCompilationData(compilerCall);
         var documents = new List<DocumentInfo>();
         var additionalDocuments = new List<DocumentInfo>();
@@ -115,12 +115,12 @@ public sealed class SolutionReader : IDisposable
             }
         }
 
+
         // https://github.com/jaredpar/complog/issues/24
         // Need to store project reference information at the builder point so they can be properly repacked
         // here and setup in the Workspace
-        var projectReferences = new List<ProjectReference>();
 
-        var referenceList = Reader.RenameMetadataReferences(FilterToUnique(rawCompilationData.References));
+        var referenceList = Reader.ReadMetadataReferences(FilterToUnique(rawCompilationData.References));
         var analyzers = Reader.ReadAnalyzers(rawCompilationData);
         var options = Reader.ReadCompilerOptions(compilerCall);
         var projectInfo = ProjectInfo.Create(
@@ -143,9 +143,6 @@ public sealed class SolutionReader : IDisposable
 
         return projectInfo.WithAnalyzerConfigDocuments(analyzerConfigDocuments);
 
-        // The command line compiler supports having the same reference added multiple times. It's actually
-        // not uncommon for Microsoft.VisualBasic.dll to be passed twice when working on Visual Basic projects. 
-        // The workspaces layer though cannot handle duplicates hence we need to run a de-dupe pass here.
         static List<RawReferenceData> FilterToUnique(List<RawReferenceData> referenceList)
         {
             var hashSet = new HashSet<Guid>();
@@ -159,6 +156,36 @@ public sealed class SolutionReader : IDisposable
             }
 
             return list;
+        }
+
+        (List<ProjectReference>, List<MetadataReference>) ReadReferences(List<RawReferenceData> rawReferenceDataList)
+        {
+            // The command line compiler supports having the same reference added multiple times. It's actually
+            // not uncommon for Microsoft.VisualBasic.dll to be passed twice when working on Visual Basic projects. 
+            // The workspaces layer though cannot handle duplicates hence we need to run a de-dupe pass here.
+            var hashSet = new HashSet<Guid>();
+            var projectReferences = new List<ProjectReference>();
+            var metadataReferences = new List<MetadataReference>(rawReferenceDataList.Count);
+            foreach (var rawReferenceData in rawCompilationData.References)
+            {
+                if (!hashSet.Add(rawReferenceData.Mvid))
+                {
+                    continue;
+                }
+
+                if (Reader.TryGetCompilerCallIndex(rawReferenceData.Mvid, out var refCompilerCallIndex))
+                {
+                    var refProjectId = _indexToProjectDataMap[refCompilerCallIndex].ProjectId;
+                    projectReferences.Add(new ProjectReference(refProjectId, rawReferenceData.Aliases, rawReferenceData.EmbedInteropTypes));
+                }
+                else
+                {
+                    var metadataReference = Reader.ReadMetadataReference(rawReferenceData);
+                    metadataReferences.Add(metadataReference);
+                }
+            }
+
+            return (projectReferences, metadataReferences);
         }
     }
 }

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -115,12 +115,7 @@ public sealed class SolutionReader : IDisposable
             }
         }
 
-
-        // https://github.com/jaredpar/complog/issues/24
-        // Need to store project reference information at the builder point so they can be properly repacked
-        // here and setup in the Workspace
-
-        var referenceList = Reader.ReadMetadataReferences(FilterToUnique(rawCompilationData.References));
+        var refTuple = ReadReferences(rawCompilationData.References);
         var analyzers = Reader.ReadAnalyzers(rawCompilationData);
         var options = Reader.ReadCompilerOptions(compilerCall);
         var projectInfo = ProjectInfo.Create(
@@ -134,29 +129,14 @@ public sealed class SolutionReader : IDisposable
             compilationOptions: options.CompilationOptions,
             parseOptions: options.ParseOptions,
             documents,
-            projectReferences,
-            referenceList,
+            refTuple.Item1,
+            refTuple.Item2,
             analyzerReferences: analyzers.AnalyzerReferences,
             additionalDocuments,
             isSubmission: false,
             hostObjectType: null);
 
         return projectInfo.WithAnalyzerConfigDocuments(analyzerConfigDocuments);
-
-        static List<RawReferenceData> FilterToUnique(List<RawReferenceData> referenceList)
-        {
-            var hashSet = new HashSet<Guid>();
-            var list = new List<RawReferenceData>(capacity: referenceList.Count);
-            foreach (var data in referenceList)
-            {
-                if (hashSet.Add(data.Mvid))
-                {
-                    list.Add(data);
-                }
-            }
-
-            return list;
-        }
 
         (List<ProjectReference>, List<MetadataReference>) ReadReferences(List<RawReferenceData> rawReferenceDataList)
         {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,4 +7,12 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- 
+      The CVE in System.Text.Json doesn't apply us. Will remove suppressing once MSBuild / Roslyn 
+      produces a package that handles the issue.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds support for detecting project references when reading through the binlog. This is mostly based on matching a compiler call with its output binaries (by MVID) and then re-hydrating project references based off of that. 

closes #24