### PR TITLE
Test crash / timeout

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,6 +32,11 @@ jobs:
       TEST_ARTIFACTS_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test
       TEST_RESULTS_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test-results
       TEST_COVERAGE_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}coverage
+      DOTNET_DbgEnableMiniDump: 1
+      DOTNET_DbgMiniDumpType: 2
+      DOTNET_CreateDumpLogToFile: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test${{ matrix.slash }}%e-%p.dmp
+
+    timeout-minutes: 30
 
     name: Build and Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -59,6 +64,7 @@ jobs:
     - name: Test Linux
       run: >
         dotnet test --no-build --framework net8.0 
+        --blame-hang --blame-hang-dump-type full --blame--hang-timeout 10m
         --logger "console;verbosity=detailed"
         --logger "trx;LogFileName=${{ env.TEST_RESULTS_PATH }}/TestResults-Linux.trx"
         -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=${{ env.TEST_COVERAGE_PATH }}/coverage.linux.xml
@@ -67,6 +73,7 @@ jobs:
     - name: Test Windows .NET Core
       run: >
         dotnet test --no-build --framework net8.0
+        --blame-hang --blame-hang-dump-type full --blame--hang-timeout 10m
         --logger "console;verbosity=detailed"
         --logger "trx;LogFileName=${{ env.TEST_RESULTS_PATH}}/TestResults-Windows-Core.trx"
         -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=${{ env.TEST_COVERAGE_PATH }}/coverage.windows.core.xml
@@ -75,6 +82,7 @@ jobs:
     - name: Test Windows .NET Framework
       run: >
         dotnet test --no-build --framework net8.0
+        --blame-hang --blame-hang-dump-type full --blame--hang-timeout 10m
         --logger "console;verbosity=detailed"
         --logger "trx;LogFileName=${{ env.TEST_RESULTS_PATH}}/TestResults-Windows-Framework.trx"
         -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=${{ env.TEST_COVERAGE_PATH }}/coverage.windows.framework.xml
@@ -100,12 +108,12 @@ jobs:
       if: always()
       with:
         name: test-results
-        path: ${{ env.TEST_RESULTS_PATH }}/*.trx
+        path: ${{ env.TEST_RESULTS_PATH }}
 
     - name: Publish Test Artifacts
       uses: actions/upload-artifact@v3
       if: always()
       with:
         name: Test Artifacts ${{ matrix.os }}
-        path: $ {{ env.TEST_ARTIFACTS_PATH }}
+        path: ${{ env.TEST_ARTIFACTS_PATH }}
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Test Linux
       run: >
         dotnet test --no-build --framework net8.0 
-        --blame-hang --blame-hang-dump-type full --blame--hang-timeout 10m
+        --blame-hang --blame-hang-dump-type full --blame-hang-timeout 10m
         --logger "console;verbosity=detailed"
         --logger "trx;LogFileName=${{ env.TEST_RESULTS_PATH }}/TestResults-Linux.trx"
         -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=${{ env.TEST_COVERAGE_PATH }}/coverage.linux.xml
@@ -73,7 +73,7 @@ jobs:
     - name: Test Windows .NET Core
       run: >
         dotnet test --no-build --framework net8.0
-        --blame-hang --blame-hang-dump-type full --blame--hang-timeout 10m
+        --blame-hang --blame-hang-dump-type full --blame-hang-timeout 10m
         --logger "console;verbosity=detailed"
         --logger "trx;LogFileName=${{ env.TEST_RESULTS_PATH}}/TestResults-Windows-Core.trx"
         -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=${{ env.TEST_COVERAGE_PATH }}/coverage.windows.core.xml
@@ -82,7 +82,7 @@ jobs:
     - name: Test Windows .NET Framework
       run: >
         dotnet test --no-build --framework net8.0
-        --blame-hang --blame-hang-dump-type full --blame--hang-timeout 10m
+        --blame-hang --blame-hang-dump-type full --blame-hang-timeout 10m
         --logger "console;verbosity=detailed"
         --logger "trx;LogFileName=${{ env.TEST_RESULTS_PATH}}/TestResults-Windows-Framework.trx"
         -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=${{ env.TEST_COVERAGE_PATH }}/coverage.windows.framework.xml


### PR DESCRIPTION
Setup the CI so that it collects better logs when tests hang or timeout.