### PR TITLE
Use NuGetAuditSuppress

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -24,9 +24,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" />
     <PackageReference Include="System.Buffers" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Basic.CompilerLog/Basic.CompilerLog.csproj
+++ b/src/Basic.CompilerLog/Basic.CompilerLog.csproj
@@ -33,7 +33,6 @@
     <Content Include="..\..\LICENSE" PackagePath="\" />
     <PackageReference Include="Mono.Options" />
     <ProjectReference Include="..\Basic.CompilerLog.Util\Basic.CompilerLog.Util.csproj" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,9 +10,11 @@
 
   <ItemGroup>
     <!-- 
-      The CVE in System.Text.Json doesn't apply us. Will remove suppressing once MSBuild / Roslyn 
+      The CVE in System.Text.Json, Microsoft.IO.Redist don't apply us. Will remove suppressing once MSBuild / Roslyn 
       produces a package that handles the issue.
     -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hq7w-xv5x-g34j" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,13 +16,11 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="7.0.13" />
-    <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.10.0" />
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.243" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />

--- a/src/Scratch/Scratch.csproj
+++ b/src/Scratch/Scratch.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
These CVE don't apply so using a suppression vs. changing build semantics