### PR TITLE
Fix compilation name from binlog

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,14 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/artifacts/bin/Basic.CompilerLog/debug_net8.0/Basic.CompilerLog.dll",
-            "args": ["export", "C:\\Users\\jaredpar\\Downloads\\Build1.complog"],
-            "cwd": "C:\\Users\\jaredpar\\Downloads",
+            "program": "${workspaceFolder}/artifacts/bin/Basic.CompilerLog/debug_net9.0/Basic.CompilerLog.dll",
+            "args": [
+                "replay",
+                "/home/jaredpar/code/msbuild/artifacts/log/Debug/Build.binlog",
+                "-p",
+                "StringTools.UnitTests.csproj",
+                "-n"],
+            "cwd": "/home/jaredpar/code/msbuild/artifacts/log/Debug",
             // "cwd": "${workspaceFolder}/src/Basic.CompilerLog",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -162,6 +162,22 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
+    public void KeyFileAssemblyName()
+    {
+        Go(Fixture.ConsoleComplex.Value.BinaryLogPath!);
+        Go(Fixture.ConsoleComplex.Value.CompilerLogPath);
+
+        void Go(string filePath)
+        {
+            using var reader = CompilerCallReaderUtil.Create(filePath, BasicAnalyzerKind.None);
+            var compilerCall = reader.ReadCompilerCall(0);
+            var data = reader.ReadCompilationData(compilerCall);
+            var compilation = data.GetCompilationAfterGenerators();
+            Assert.Equal("console-complex", compilation.AssemblyName);
+        }
+    }
+
+    [Fact]
     public void AdditionalFiles()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplex.Value.CompilerLogPath);

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -119,9 +119,10 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
     {
         var args = ReadCommandLineArguments(compilerCall);
         var assemblyFileName = RoslynUtil.GetAssemblyFileName(args);
+        var compilationName = Path.GetFileNameWithoutExtension(assemblyFileName);
         var data = new CompilerCallData(
             compilerCall,
-            assemblyFileName,
+            compilationName,
             args.OutputDirectory,
             args.ParseOptions,
             args.CompilationOptions,

--- a/src/Basic.CompilerLog/FilterOptionSet.cs
+++ b/src/Basic.CompilerLog/FilterOptionSet.cs
@@ -35,7 +35,6 @@ internal sealed class FilterOptionSet : OptionSet
         Add("all", "include all compilation kinds", i => { if (i is not null) IncludeAllKinds = true; });
         Add("f|framework=", "include only compilations for the target framework (allows multiple)", TargetFrameworks.Add);
         Add("p|project=", "include only compilations for the given project (allows multiple)", ProjectNames.Add);
-        Add("n|projectName=", "include only compilations for the project", ProjectNames.Add, hidden: true);
         Add("h|help", "print help", h => { if (h != null) Help = true; });
 
         if (analyzers)
@@ -43,7 +42,7 @@ internal sealed class FilterOptionSet : OptionSet
             _hasAnalyzerOptions = true;
             _basicAnalyzerKind = BasicAnalyzerHost.DefaultKind;
             Add("a|analyzers=", "analyzer load strategy: none, ondisk, inmemory", void (BasicAnalyzerKind k) => _basicAnalyzerKind = k);
-            Add("none", "Do not run analyzers", i => { if (i is not null) _basicAnalyzerKind = BasicAnalyzerKind.None; }, hidden: true);
+            Add("n|none", "Do not run analyzers", i => { if (i is not null) _basicAnalyzerKind = BasicAnalyzerKind.None; }, hidden: true);
         }
     }
 

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.IO.Pipelines;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -24,8 +25,14 @@ using TraceReloggerLib;
 
 #pragma warning disable 8321
 
-var temp = CompilerLogUtil.GetOrCreateCompilerLogStream(@"C:\Users\jaredpar\code\roslyn\src\Compilers\Core\Portable\msbuild.binlog");
-
+using var reader = CompilerCallReaderUtil.Create("/home/jaredpar/code/msbuild/artifacts/log/Debug/Build.binlog", BasicAnalyzerKind.None);
+var compilerCall = reader
+    .ReadAllCompilerCalls()
+    .Single(x => x.ProjectFileName == "StringTools.UnitTests.csproj");
+var data = reader.ReadCompilationData(compilerCall);
+var compilation = data.GetCompilationAfterGenerators();
+Console.WriteLine(compilation.AssemblyName);
+var diagnostics = compilation.GetDiagnostics();
 
 Bing();
 void Bing()


### PR DESCRIPTION
The compilation name was being set to the full assembly name including the extension. That breaks IVT as compilation name is used for IVT checking and hence can't include the extension.

closes #187