### PR TITLE
Move to xUnit v3

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/AppDomainUtils.cs
+++ b/src/Basic.CompilerLog.UnitTests/AppDomainUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Basic.CompilerLog.UnitTests;
 
@@ -58,16 +59,24 @@ public sealed class AppDomainTestOutputHelper : MarshalByRefObject, ITestOutputH
 {
     public ITestOutputHelper TestOutputHelper { get; }
 
+    public string Output => TestOutputHelper.Output;
+
     public AppDomainTestOutputHelper(ITestOutputHelper testOutputHelper)
     {
         TestOutputHelper = testOutputHelper;
     }
+
+    public void Write(string message) =>
+        TestOutputHelper.Write(message);
 
     public void WriteLine(string message) =>
         TestOutputHelper.WriteLine(message);
 
     public void WriteLine(string format, params object[] args) =>
         TestOutputHelper.WriteLine(format, args);
+
+    public void Write(string format, params object[] args) =>
+        TestOutputHelper.Write(format, args);
 }
 
 public sealed class InvokeUtil : MarshalByRefObject

--- a/src/Basic.CompilerLog.UnitTests/AppDomainUtils.cs
+++ b/src/Basic.CompilerLog.UnitTests/AppDomainUtils.cs
@@ -81,6 +81,13 @@ public sealed class AppDomainTestOutputHelper : MarshalByRefObject, ITestOutputH
 
 public sealed class InvokeUtil : MarshalByRefObject
 {
+    private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+    internal void Cancel()
+    {
+        _cts.Cancel();
+    }
+
     internal void Invoke<T>(string typeName, string methodName, ITestOutputHelper testOutputHelper, T state)
     {
         var type = typeof(AppDomainUtils).Assembly.GetType(typeName, throwOnError: false)!;
@@ -94,7 +101,7 @@ public sealed class InvokeUtil : MarshalByRefObject
 
         try
         {
-            member.Invoke(obj, [testOutputHelper, state]);
+            member.Invoke(obj, [testOutputHelper, state, _cts.Token]);
         }
         catch (TargetInvocationException ex)
         {

--- a/src/Basic.CompilerLog.UnitTests/AppDomainUtils.cs
+++ b/src/Basic.CompilerLog.UnitTests/AppDomainUtils.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/AssertEx.cs
+++ b/src/Basic.CompilerLog.UnitTests/AssertEx.cs
@@ -1,7 +1,6 @@
 
 using Basic.CompilerLog.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>CS0436</NoWarn>
+    <NoWarn>$(NoWarn);CS0436;xUnit1051</NoWarn>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -5,8 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>CS0436</NoWarn>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,22 +13,21 @@
     <Compile Include="..\Shared\DotnetUtil.cs" Link="DotnetUtil.cs" />
     <Compile Include="..\Shared\PathUtil.cs" Link="PathUtil.cs" />
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" />
     <ProjectReference Include="..\Basic.CompilerLog.Util\Basic.CompilerLog.Util.csproj" />
     <ProjectReference Include="..\Basic.CompilerLog\Basic.CompilerLog.csproj" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" />
-    <PackageReference Include="coverlet.msbuild" >
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" >
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Xunit.Combinatorial" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);CS0436;xUnit1051</NoWarn>
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
@@ -23,8 +23,8 @@ public sealed class BasicAnalyzerHostTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public BasicAnalyzerHostTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogReaderTests))
+    public BasicAnalyzerHostTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
     {
         Fixture = fixture;
     }
@@ -83,7 +83,7 @@ public sealed class BasicAnalyzerHostTests : TestBase
             [],
             Basic.Reference.Assemblies.Net60.References.All);
         var driver = CSharpGeneratorDriver.Create([host.Generator!]);
-        driver.RunGeneratorsAndUpdateCompilation(compilation, out var compilation2, out var diagnostics);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var compilation2, out var diagnostics, CancellationToken);
         Assert.Empty(diagnostics);
         var syntaxTrees = compilation2.SyntaxTrees.ToList();
         Assert.Equal(2, syntaxTrees.Count);

--- a/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Xunit;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CSharp;
-using Xunit.Abstractions;
 
 #if NET
 using System.Runtime.Loader;

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
@@ -24,8 +24,8 @@ public sealed class BinaryLogReaderTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public BinaryLogReaderTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogReaderTests))
+    public BinaryLogReaderTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
     {
         Fixture = fixture;
     }
@@ -151,13 +151,13 @@ public sealed class BinaryLogReaderTests : TestBase
     [MemberData(nameof(GetSupportedBasicAnalyzerKinds))]
     public void GetCompilationSimple(BasicAnalyzerKind basicAnalyzerKind)
     {
-        RunInContext((FilePath: Fixture.Console.Value.BinaryLogPath!, Kind: basicAnalyzerKind), static (testOutptuHelper, state) =>
+        RunInContext((FilePath: Fixture.Console.Value.BinaryLogPath!, Kind: basicAnalyzerKind), static (testOutptuHelper, state, cancellationToken) =>
         {
             using var reader = BinaryLogReader.Create(state.FilePath, state.Kind);
             var compilerCall = reader.ReadAllCompilerCalls().First();
             var compilationData = reader.ReadCompilationData(compilerCall);
             Assert.NotNull(compilationData);
-            var emitResult = compilationData.EmitToMemory();
+            var emitResult = compilationData.EmitToMemory(cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
         });
     }
@@ -174,7 +174,7 @@ public sealed class BinaryLogReaderTests : TestBase
 
         using var reader = BinaryLogReader.Create(Path.Combine(dir, "msbuild.binlog"), BasicAnalyzerKind.None);
         var data = reader.ReadAllCompilationData().Single();
-        var diagnostic = data.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error).Single();
+        var diagnostic = data.GetDiagnostics(CancellationToken).Where(x => x.Severity == DiagnosticSeverity.Error).Single();
         Assert.Contains("Can't find portable pdb file for", diagnostic.GetMessage());
 
         Assert.Throws<InvalidOperationException>(() => reader.ReadAllGeneratedSourceTexts(data.CompilerCall));

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
@@ -16,7 +16,6 @@ using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
@@ -2,7 +2,6 @@
 using Basic.CompilerLog.Util;
 using Basic.CompilerLog.Util.Impl;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
@@ -10,8 +10,8 @@ public sealed class CodeAnalysisExtensionsTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public CodeAnalysisExtensionsTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilationDataTests))
+    public CodeAnalysisExtensionsTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilationDataTests))
     {
         Fixture = fixture;
     }
@@ -20,15 +20,15 @@ public sealed class CodeAnalysisExtensionsTests : TestBase
     public void EmitToMemory()
     {
         var data = GetCompilationData(Fixture.ClassLib.Value.CompilerLogPath, basicAnalyzerKind: BasicAnalyzerKind.None);
-        var compilation = data.GetCompilationAfterGenerators();
-        var result = compilation.EmitToMemory(EmitFlags.Default);
+        var compilation = data.GetCompilationAfterGenerators(CancellationToken);
+        var result = compilation.EmitToMemory(EmitFlags.Default, cancellationToken: CancellationToken);
         AssertEx.Success(TestOutputHelper, result);
         AssertEx.HasData(result.AssemblyStream);
         Assert.Null(result.PdbStream);
         Assert.Null(result.XmlStream);
         Assert.Null(result.MetadataStream);
 
-        result = compilation.EmitToMemory(EmitFlags.IncludePdbStream);
+        result = compilation.EmitToMemory(EmitFlags.IncludePdbStream, cancellationToken: CancellationToken);
         AssertEx.Success(TestOutputHelper, result);
         AssertEx.HasData(result.AssemblyStream);
         AssertEx.HasData(result.PdbStream);

--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -1,6 +1,7 @@
 
 using Basic.CompilerLog.Util;
 using Basic.CompilerLog.Util.Impl;
+using Microsoft.Testing.Platform.Extensions.Messages;
 using Xunit;
 
 namespace Basic.CompilerLog.UnitTests;
@@ -10,8 +11,8 @@ public sealed class CompilationDataTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public CompilationDataTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilationDataTests))
+    public CompilationDataTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilationDataTests))
     {
         Fixture = fixture;
     }
@@ -19,40 +20,40 @@ public sealed class CompilationDataTests : TestBase
     [Fact]
     public void EmitToMemoryCombinations()
     {
-        RunInContext(Fixture.ClassLib.Value.CompilerLogPath, static (testOutputHelper, filePath) =>
+        RunInContext(Fixture.ClassLib.Value.CompilerLogPath, static (testOutputHelper, filePath, cancellationToken) =>
         {
             using var reader = CompilerLogReader.Create(filePath);
             var data = reader.ReadCompilationData(0);
 
-            var emitResult = data.EmitToMemory();
+            var emitResult = data.EmitToMemory(cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
             AssertEx.HasData(emitResult.AssemblyStream);
             AssertEx.HasData(emitResult.PdbStream);
             Assert.Null(emitResult.XmlStream);
             AssertEx.HasData(emitResult.MetadataStream);
 
-            emitResult = data.EmitToMemory(EmitFlags.IncludePdbStream);
+            emitResult = data.EmitToMemory(EmitFlags.IncludePdbStream, cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
             AssertEx.HasData(emitResult.AssemblyStream);
             AssertEx.HasData(emitResult.PdbStream);
             Assert.Null(emitResult.XmlStream);
             Assert.Null(emitResult.MetadataStream);
 
-            emitResult = data.EmitToMemory(EmitFlags.IncludePdbStream | EmitFlags.IncludeXmlStream);
+            emitResult = data.EmitToMemory(EmitFlags.IncludePdbStream | EmitFlags.IncludeXmlStream, cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
             AssertEx.HasData(emitResult.AssemblyStream);
             AssertEx.HasData(emitResult.PdbStream);
             AssertEx.HasData(emitResult.XmlStream);
             Assert.Null(emitResult.MetadataStream);
 
-            emitResult = data.EmitToMemory(EmitFlags.IncludePdbStream | EmitFlags.IncludeXmlStream | EmitFlags.IncludeMetadataStream);
+            emitResult = data.EmitToMemory(EmitFlags.IncludePdbStream | EmitFlags.IncludeXmlStream | EmitFlags.IncludeMetadataStream, cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
             AssertEx.HasData(emitResult.AssemblyStream);
             AssertEx.HasData(emitResult.PdbStream);
             AssertEx.HasData(emitResult.XmlStream);
             AssertEx.HasData(emitResult.MetadataStream);
 
-            emitResult = data.EmitToMemory(EmitFlags.MetadataOnly);
+            emitResult = data.EmitToMemory(EmitFlags.MetadataOnly, cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
             AssertEx.HasData(emitResult.AssemblyStream);
             Assert.Null(emitResult.PdbStream);
@@ -64,11 +65,11 @@ public sealed class CompilationDataTests : TestBase
     [Fact]
     public void EmitToMemoryRefOnly()
     {
-        RunInContext(Fixture.ClassLibRefOnly.Value.CompilerLogPath, static (testOutputHelper, filePath) =>
+        RunInContext(Fixture.ClassLibRefOnly.Value.CompilerLogPath, static (testOutputHelper, filePath, cancellationToken) =>
         {
             using var reader = CompilerLogReader.Create(filePath);
             var data = reader.ReadCompilationData(0);
-            var result = data.EmitToMemory();
+            var result = data.EmitToMemory(cancellationToken: cancellationToken);
             Assert.True(result.Success);
         });
     }
@@ -91,7 +92,7 @@ public sealed class CompilationDataTests : TestBase
         using var reader = CompilerLogReader.Create(Fixture.ClassLibWithResourceLibs.Value.CompilerLogPath, BasicAnalyzerKind.None);
         var data = reader.ReadCompilationData(1);
         Assert.Equal(CompilerCallKind.Satellite, data.Kind);
-        var result = data.EmitToMemory();
+        var result = data.EmitToMemory(cancellationToken: CancellationToken);
         Assert.True(result.Success);
     }
 
@@ -113,14 +114,14 @@ public sealed class CompilationDataTests : TestBase
         using var reader = CompilerLogReader.Create(Fixture.ClassLibWithResourceLibs.Value.CompilerLogPath, BasicAnalyzerKind.None);
         var data = reader.ReadCompilationData(1);
         Assert.Equal(CompilerCallKind.Satellite, data.Kind);
-        var result = data.EmitToDisk(Root.DirectoryPath);
+        var result = data.EmitToDisk(Root.DirectoryPath, cancellationToken: CancellationToken);
         Assert.True(result.Success);
     }
 
     [Fact]
     public void GetAnalyzersNormal()
     {
-        RunInContext(Fixture.ClassLib.Value.CompilerLogPath, static (testOtputHelper, filePath) =>
+        RunInContext(Fixture.ClassLib.Value.CompilerLogPath, static (testOtputHelper, filePath, _) =>
         {
             using var reader = CompilerLogReader.Create(filePath);
             var data = reader.ReadCompilationData(0);
@@ -141,18 +142,18 @@ public sealed class CompilationDataTests : TestBase
     {
         using var reader = CompilerLogReader.Create(Fixture.ClassLib.Value.CompilerLogPath, BasicAnalyzerKind.None);
         var data = reader.ReadCompilationData(0);
-        Assert.NotEmpty(data.GetDiagnostics());
+        Assert.NotEmpty(data.GetDiagnostics(CancellationToken));
     }
 
     [Theory]
     [MemberData(nameof(GetSupportedBasicAnalyzerKinds))]
     public void GetAllDiagnostics(BasicAnalyzerKind basicAnalyzerKind)
     {
-        RunInContext((FilePath: Fixture.ClassLib.Value.CompilerLogPath, Kind: basicAnalyzerKind), static (testOutputHelper, state) =>
+        RunInContext((FilePath: Fixture.ClassLib.Value.CompilerLogPath, Kind: basicAnalyzerKind), static (testOutputHelper, state, cancellationToken) =>
         {
             using var reader = CompilerLogReader.Create(state.FilePath, state.Kind);
             var data = reader.ReadCompilationData(0);
-            Assert.NotEmpty(data.GetAllDiagnosticsAsync().Result);
+            Assert.NotEmpty(data.GetAllDiagnosticsAsync(cancellationToken).Result);
         });
     }
 
@@ -171,13 +172,13 @@ public sealed class CompilationDataTests : TestBase
             data.AdditionalTexts,
             host,
             data.AnalyzerConfigOptionsProvider);
-        Assert.NotEmpty(await data.GetAllDiagnosticsAsync());
+        Assert.NotEmpty(await data.GetAllDiagnosticsAsync(CancellationToken));
     }
 
     [Fact]
     public void GetCompilationAfterGeneratorsDiagnostics()
     {
-        RunInContext(Fixture.Console.Value.CompilerLogPath, static (testOutputHelper, logFilePath) =>
+        RunInContext(Fixture.Console.Value.CompilerLogPath, static (testOutputHelper, logFilePath, cancellationToken) =>
         {
             using var reader = CompilerLogReader.Create(
                 logFilePath,
@@ -199,7 +200,7 @@ public sealed class CompilationDataTests : TestBase
                 data.AdditionalTexts,
                 host,
                 data.AnalyzerConfigOptionsProvider);
-            _ = data.GetCompilationAfterGenerators(out var diagnostics);
+            _ = data.GetCompilationAfterGenerators(out var diagnostics, cancellationToken);
             Assert.NotEmpty(diagnostics);
         });
     }
@@ -210,10 +211,10 @@ public sealed class CompilationDataTests : TestBase
     {
         using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath, basicAnalyzerKind);
         var data = reader.ReadAllCompilationData().Single();
-        var trees = data.GetGeneratedSyntaxTrees();
+        var trees = data.GetGeneratedSyntaxTrees(CancellationToken);
         Assert.Single(trees);
 
-        trees = data.GetGeneratedSyntaxTrees(out var diagnostics);
+        trees = data.GetGeneratedSyntaxTrees(out var diagnostics, CancellationToken);
         Assert.Single(trees);
         Assert.Empty(diagnostics);
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -2,7 +2,6 @@
 using Basic.CompilerLog.Util;
 using Basic.CompilerLog.Util.Impl;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerCallReaderUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerCallReaderUtilTests.cs
@@ -8,8 +8,8 @@ public sealed class CompilerCallReaderUtilTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public CompilerCallReaderUtilTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogReaderTests))
+    public CompilerCallReaderUtilTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilerCallReaderUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerCallReaderUtilTests.cs
@@ -1,6 +1,5 @@
 using Basic.CompilerLog.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 
@@ -22,7 +21,7 @@ public sealed class CompilerCallReaderUtilTests : TestBase
     }
 
     [Theory]
-    [CombinatorialData]
+    [MemberData(nameof(GetBasicAnalyzerKinds))]
     public void GetAllAnalyzerKinds(BasicAnalyzerKind basicAnalyzerKind)
     {
         using var reader = CompilerCallReaderUtil.Create(Fixture.Console.Value.CompilerLogPath!, basicAnalyzerKind);

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -1,6 +1,5 @@
 using Basic.CompilerLog.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -8,8 +8,8 @@ public sealed class CompilerLogBuilderTests : TestBase
 {
     public SolutionFixture Fixture { get; }
 
-    public CompilerLogBuilderTests(ITestOutputHelper testOutputHelper, SolutionFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogBuilderTests))
+    public CompilerLogBuilderTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, SolutionFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogBuilderTests))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
@@ -29,8 +29,8 @@ public sealed class CompilerLogReaderExTests : TestBase
 {
     public SolutionFixture Fixture { get; }
 
-    public CompilerLogReaderExTests(ITestOutputHelper testOutputHelper, SolutionFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogReaderTests))
+    public CompilerLogReaderExTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, SolutionFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
@@ -16,7 +16,6 @@ using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -16,7 +16,6 @@ using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -24,8 +24,8 @@ public sealed class CompilerLogReaderTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public CompilerLogReaderTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogReaderTests))
+    public CompilerLogReaderTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
     {
         Fixture = fixture;
     }
@@ -171,7 +171,7 @@ public sealed class CompilerLogReaderTests : TestBase
             using var reader = CompilerCallReaderUtil.Create(filePath, BasicAnalyzerKind.None);
             var compilerCall = reader.ReadCompilerCall(0);
             var data = reader.ReadCompilationData(compilerCall);
-            var compilation = data.GetCompilationAfterGenerators();
+            var compilation = data.GetCompilationAfterGenerators(cancellationToken: CancellationToken);
             Assert.Equal("console-complex", compilation.AssemblyName);
         }
     }
@@ -185,7 +185,7 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.Equal("additional.txt", Path.GetFileName(data.AdditionalTexts[0].Path));
 
         var additionalText = data.AdditionalTexts[0]!;
-        var text = additionalText.GetText()!;
+        var text = additionalText.GetText(CancellationToken)!;
         Assert.Contains("This is an additional file", text.ToString());
 
         var options = data.AnalyzerConfigOptionsProvider.GetOptions(additionalText);
@@ -196,11 +196,11 @@ public sealed class CompilerLogReaderTests : TestBase
     [MemberData(nameof(GetSupportedBasicAnalyzerKinds))]
     public void AnalyzerLoadOptions(BasicAnalyzerKind basicAnalyzerKind)
     {
-        RunInContext((FilePath: Fixture.Console.Value.CompilerLogPath, Kind: basicAnalyzerKind), static (testOutputHelper, state) =>
+        RunInContext((FilePath: Fixture.Console.Value.CompilerLogPath, Kind: basicAnalyzerKind), static (testOutputHelper, state, cancellationToken) =>
         {
             using var reader = CompilerLogReader.Create(state.FilePath, state.Kind);
             var data = reader.ReadCompilationData(0);
-            var compilation = data.GetCompilationAfterGenerators(out var diagnostics);
+            var compilation = data.GetCompilationAfterGenerators(out var diagnostics, cancellationToken);
             Assert.Empty(diagnostics);
             var found = false;
             foreach (var tree in compilation.SyntaxTrees)
@@ -307,8 +307,8 @@ public sealed class CompilerLogReaderTests : TestBase
     {
         using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath, BasicAnalyzerKind.None);
         var data = reader.ReadCompilationData(0);
-        var tree = data.GetCompilationAfterGenerators().SyntaxTrees.Last();
-        var decls = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().ToList();
+        var tree = data.GetCompilationAfterGenerators(CancellationToken).SyntaxTrees.Last();
+        var decls = tree.GetRoot(CancellationToken).DescendantNodes().OfType<ClassDeclarationSyntax>().ToList();
         Assert.True(decls.Count >= 2);
         Assert.Equal("Util", decls[0].Identifier.Text);
         Assert.Equal("GetRegex_0", decls[1].Identifier.Text);
@@ -320,7 +320,7 @@ public sealed class CompilerLogReaderTests : TestBase
         using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath, BasicAnalyzerKind.None);
         var data = reader.ReadCompilationData(0);
         var compilation1 = data.Compilation;
-        var compilation2 = data.GetCompilationAfterGenerators();
+        var compilation2 = data.GetCompilationAfterGenerators(CancellationToken);
         Assert.NotSame(compilation1, compilation2);
         Assert.Single(data.AnalyzerReferences);
     }
@@ -331,7 +331,7 @@ public sealed class CompilerLogReaderTests : TestBase
         using var reader = CompilerLogReader.Create(Fixture.ConsoleNoGenerator.Value.CompilerLogPath, BasicAnalyzerKind.None);
         var data = reader.ReadCompilationData(0);
         var compilation1 = data.Compilation;
-        var compilation2 = data.GetCompilationAfterGenerators();
+        var compilation2 = data.GetCompilationAfterGenerators(CancellationToken);
         Assert.Same(compilation1, compilation2);
         Assert.Single(data.AnalyzerReferences);
     }
@@ -377,7 +377,7 @@ public sealed class CompilerLogReaderTests : TestBase
         var compilerCall = reader.ReadCompilerCall(0);
         Assert.False(reader.HasAllGeneratedFileContent(compilerCall));
         var data = reader.ReadCompilationData(0);
-        var compilation = data.GetCompilationAfterGenerators(out var diagnostics);
+        var compilation = data.GetCompilationAfterGenerators(out var diagnostics, CancellationToken);
         Assert.Single(diagnostics);
         Assert.Equal(BasicAnalyzerHostNone.CannotReadGeneratedFiles.Id, diagnostics[0].Id);
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogUtilTests.cs
@@ -1,6 +1,5 @@
 using Basic.CompilerLog.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogUtilTests.cs
@@ -8,8 +8,8 @@ public sealed class CompilerLogUtilTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public CompilerLogUtilTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilerLogReaderTests))
+    public CompilerLogUtilTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/ConditionalFacts.cs
+++ b/src/Basic.CompilerLog.UnitTests/ConditionalFacts.cs
@@ -5,12 +5,13 @@ using Xunit;
 
 public sealed class WindowsFactAttribute : FactAttribute
 {
+    public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
     public WindowsFactAttribute()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Skip = "This test is only supported on Windows";
-        }
+        SkipUnless = nameof(WindowsFactAttribute.IsWindows);
+        SkipType = typeof(WindowsFactAttribute);
+        Skip = "This test is only supported on Windows";
     }
 }
 
@@ -18,21 +19,21 @@ public sealed class WindowsTheoryAttribute : TheoryAttribute
 {
     public WindowsTheoryAttribute()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Skip = "This test is only supported on Windows";
-        }
+        SkipUnless = nameof(WindowsFactAttribute.IsWindows);
+        SkipType = typeof(WindowsFactAttribute);
+        Skip = "This test is only supported on Windows";
     }
 }
 
 public sealed class UnixTheoryAttribute : TheoryAttribute
 {
+    public static bool IsUnix => !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
     public UnixTheoryAttribute()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Skip = "This test is only supported on Windows";
-        }
+        Skip = "This test is only supported on Unix";
+        SkipUnless = nameof(IsUnix);
+        SkipType = typeof(UnixTheoryAttribute);
     }
 }
 

--- a/src/Basic.CompilerLog.UnitTests/ConditionalFacts.cs
+++ b/src/Basic.CompilerLog.UnitTests/ConditionalFacts.cs
@@ -2,7 +2,6 @@ namespace Basic.CompilerLog.UnitTests;
 
 using System.Runtime.InteropServices;
 using Xunit;
-using Xunit.Abstractions;
 
 public sealed class WindowsFactAttribute : FactAttribute
 {

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -10,7 +10,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -18,8 +18,8 @@ public sealed class ExportUtilTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public ExportUtilTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(ExportUtilTests))
+    public ExportUtilTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(ExportUtilTests))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/Extensions.cs
+++ b/src/Basic.CompilerLog.UnitTests/Extensions.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Runner.Common;
 using Xunit.Sdk;
+using AssemblyMetadata=Microsoft.CodeAnalysis.AssemblyMetadata;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/Extensions.cs
+++ b/src/Basic.CompilerLog.UnitTests/Extensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;

--- a/src/Basic.CompilerLog.UnitTests/ExtensionsTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExtensionsTests.cs
@@ -11,8 +11,8 @@ public sealed class ExtensionsTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public ExtensionsTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(CompilationDataTests))
+    public ExtensionsTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilationDataTests))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/ExtensionsTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExtensionsTests.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using Basic.CompilerLog.Util;
 using Basic.CompilerLog.Util.Impl;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/FixtureBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/FixtureBase.cs
@@ -1,8 +1,6 @@
 
-using System.Security.Cryptography;
 using System.Text;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;

--- a/src/Basic.CompilerLog.UnitTests/FixtureBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/FixtureBase.cs
@@ -1,6 +1,7 @@
 
 using System.Text;
 using Xunit;
+using Xunit.Runner.Common;
 using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;

--- a/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
@@ -13,8 +13,8 @@ public class LogReaderStateTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public LogReaderStateTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(LogReaderState))
+    public LogReaderStateTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(LogReaderState))
     {
         Fixture = fixture;
     }

--- a/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
@@ -1,7 +1,6 @@
 
 using Basic.CompilerLog.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 #if NET
 using System.Runtime.Loader;

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -19,7 +19,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 
@@ -689,7 +688,7 @@ public sealed class ProgramTests : TestBase
     }
 
     [Theory]
-    [CombinatorialData]
+    [MemberData(nameof(GetBasicAnalyzerKinds))]
     public void GeneratedBoth(BasicAnalyzerKind basicAnalyzerKind)
     {
         RunWithBoth(logPath =>

--- a/src/Basic.CompilerLog.UnitTests/SolutionFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionFixture.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Xunit;
-using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -17,8 +17,8 @@ public sealed class SolutionReaderTests : TestBase
     public List<SolutionReader> ReaderList { get; } = new();
     public CompilerLogFixture Fixture { get; }
 
-    public SolutionReaderTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(SolutionReader))
+    public SolutionReaderTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(SolutionReader))
     {
         Fixture = fixture;
     }
@@ -54,7 +54,7 @@ public sealed class SolutionReaderTests : TestBase
             var project = solution.Projects.Single();
             Assert.NotEmpty(project.AnalyzerReferences);
             var docs = project.Documents.ToList();
-            var generatedDocs = (await project.GetSourceGeneratedDocumentsAsync()).ToList();
+            var generatedDocs = (await project.GetSourceGeneratedDocumentsAsync(CancellationToken)).ToList();
             Assert.Null(docs.FirstOrDefault(x => x.Name == "RegexGenerator.g.cs"));
             Assert.Single(generatedDocs);
             Assert.NotNull(generatedDocs.First(x => x.Name == "RegexGenerator.g.cs"));
@@ -88,9 +88,9 @@ public sealed class SolutionReaderTests : TestBase
             var utilProject = solution.GetProject(projectReference.ProjectId);
             Assert.NotNull(utilProject);
             Assert.Equal("util.csproj", utilProject.Name);
-            var compilation = await consoleProject.GetCompilationAsync();
+            var compilation = await consoleProject.GetCompilationAsync(CancellationToken);
             Assert.NotNull(compilation);
-            var result = compilation.EmitToMemory();
+            var result = compilation.EmitToMemory(cancellationToken: CancellationToken);
             Assert.True(result.Success);
         }
     }

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;

--- a/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/StringStreamTests.cs
@@ -2,7 +2,6 @@ using System.Text;
 using Basic.CompilerLog.Util;
 using DotUtils.StreamUtils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;
@@ -35,6 +34,18 @@ public abstract class TestBase : IDisposable
     internal static bool IsNetCore => false;
     internal static bool IsNetFramework => true;
 #endif
+
+    /// <summary>
+    /// Get all of the <see cref="BasicAnalyzerKind"/>
+    /// </summary>
+    /// <returns></returns>
+    public static IEnumerable<object[]> GetBasicAnalyzerKinds()
+    {
+        foreach (BasicAnalyzerKind e in Enum.GetValues(typeof(BasicAnalyzerKind)))
+        {
+            yield return new object[] { e };
+        }
+    }
 
     /// <summary>
     /// Get all of the supported <see cref="BasicAnalyzerKind"/>

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -15,8 +15,8 @@ public sealed class UsingAllCompilerLogTests : TestBase
 {
     public CompilerLogFixture Fixture { get; }
 
-    public UsingAllCompilerLogTests(ITestOutputHelper testOutputHelper, CompilerLogFixture fixture)
-        : base(testOutputHelper, nameof(UsingAllCompilerLogTests))
+    public UsingAllCompilerLogTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(UsingAllCompilerLogTests))
     {
         Fixture = fixture;
     }
@@ -65,7 +65,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
 
                     using var testDir = new TempDir();
                     TestOutputHelper.WriteLine($"{Path.GetFileName(complogPath)}: {data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                    var emitResult = data.EmitToDisk(testDir.DirectoryPath);
+                    var emitResult = data.EmitToDisk(testDir.DirectoryPath, cancellationToken: CancellationToken);
                     AssertEx.Success(TestOutputHelper, emitResult);
                     Assert.NotEmpty(emitResult.Directory);
                     Assert.NotEmpty(emitResult.AssemblyFileName);
@@ -87,7 +87,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
                         Assert.NotNull(emitResult.MetadataFilePath);
                     }
                 }
-            });
+            }, CancellationToken);
 
             list.Add(task);
         }
@@ -111,7 +111,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
             foreach (var data in reader.ReadAllCompilationData(reader.HasAllGeneratedFileContent))
             {
                 TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var generatedTrees = data.GetGeneratedSyntaxTrees();
+                var generatedTrees = data.GetGeneratedSyntaxTrees(CancellationToken);
                 foreach (var tree in generatedTrees)
                 {
                     foreach (var c in illegalChars)
@@ -135,7 +135,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
             foreach (var data in reader.ReadAllCompilationData(cc => basicAnalyzerKind != BasicAnalyzerKind.None || reader.HasAllGeneratedFileContent(cc)))
             {
                 TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var emitResult = data.EmitToMemory();
+                var emitResult = data.EmitToMemory(cancellationToken: CancellationToken);
                 AssertEx.Success(TestOutputHelper, emitResult);
             }
         }
@@ -162,7 +162,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
                 }
 
                 TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var emitResult = data.EmitToMemory();
+                var emitResult = data.EmitToMemory(cancellationToken: CancellationToken);
                 TestOutputHelper.WriteLine(string.Join(Environment.NewLine, emitResult.Diagnostics.Select(d => d.ToString())));
                 AssertEx.Success(TestOutputHelper, emitResult);
             }
@@ -215,9 +215,9 @@ public sealed class UsingAllCompilerLogTests : TestBase
             {
                 foreach (var document in project.Documents)
                 {
-                    var text = await document.GetTextAsync();
+                    var text = await document.GetTextAsync(CancellationToken);
                     var textSpan = new TextSpan(0, text.Length);
-                    _ = await Classifier.GetClassifiedSpansAsync(document, textSpan);
+                    _ = await Classifier.GetClassifiedSpansAsync(document, textSpan, CancellationToken);
                 }
             }
         }
@@ -237,7 +237,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
                 continue;
             }
 
-            var task = Task.Run(() => ExportUtilTests.TestExport(TestOutputHelper, logData.CompilerLogPath, expectedCount: null, includeAnalyzers, runBuild: true));
+            var task = Task.Run(() => ExportUtilTests.TestExport(TestOutputHelper, logData.CompilerLogPath, expectedCount: null, includeAnalyzers, runBuild: true), CancellationToken);
             list.Add(task);
         }
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,13 +16,12 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.243" />
     <PackageVersion Include="System.Buffers" Version="4.6.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3" Version="1.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Overall this was pretty straight forward after reading through the [migration guide](https://xunit.net/docs/getting-started/v3/migration). Biggest chunk of work was fixing up the xUnit1051 violations around `CancellationToken` but that was mostly mechanical. 

Did hit [one snag] in the .NET SDK when building. The fix turned out to be setting `<OutputType>Exe</OutputType>` explicitly in the xunit v3 project vs. depending on it to be set by the package. 