### PR TITLE
Fix escaping of paths in editor config

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -191,7 +191,7 @@ public sealed class ExportUtilTests : TestBase
                 .Single();
             
             var found = false;
-            var pattern = $"[{path}";
+            var pattern = $"[{RoslynUtil.EscapeEditorConfigSectionPath(path)}";
             foreach (var line in File.ReadAllLines(configFilePath))
             {
                 if (line.StartsWith(pattern, StringComparison.Ordinal))

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -151,11 +151,11 @@ public sealed class RoslynUtilTests
         Core(
             """
             is_global = true
-            [c:\example.cs]
+            [c:/example.cs]
             """,
             """
             is_global = true
-            [d:\example.cs]
+            [d:/example.cs]
             """,
             x => x.Replace("c:", "d:"));
 
@@ -166,7 +166,18 @@ public sealed class RoslynUtilTests
             """,
             """
             is_global = true
-            [c:\test.cs]
+            [c:/test.cs]
+            """,
+            x => x.Replace("example", "test"));
+
+        Core(
+            """
+            is_global = true
+            [c:/example.cs]
+            """,
+            """
+            is_global = true
+            [c:/test.cs]
             """,
             x => x.Replace("example", "test"));
 

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -1,4 +1,5 @@
 using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
 using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -148,38 +149,76 @@ public sealed class RoslynUtilTests
     [Fact]
     public void RewriteGlobalEditorConfigPaths()
     {
-        Core(
-            """
-            is_global = true
-            [c:/example.cs]
-            """,
-            """
-            is_global = true
-            [d:/example.cs]
-            """,
-            x => x.Replace("c:", "d:"));
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Core(
+                """
+                is_global = true
+                [c:/example.cs]
+                """,
+                """
+                is_global = true
+                [d:/example.cs]
+                """,
+                x => x.Replace("c:", "d:"));
 
-        Core(
-            """
-            is_global = true
-            [c:\example.cs]
-            """,
-            """
-            is_global = true
-            [c:/test.cs]
-            """,
-            x => x.Replace("example", "test"));
+            Core(
+                """
+                is_global = true
+                [c:\example.cs]
+                """,
+                """
+                is_global = true
+                [d:\example.cs]
+                """,
+                x => x.Replace("c:", "d:"));
 
-        Core(
-            """
-            is_global = true
-            [c:/example.cs]
-            """,
-            """
-            is_global = true
-            [c:/test.cs]
-            """,
-            x => x.Replace("example", "test"));
+            Core(
+                """
+                is_global = true
+                [c:\example.cs]
+                """,
+                """
+                is_global = true
+                [c:/test.cs]
+                """,
+                x => x.Replace("example", "test"));
+
+            Core(
+                """
+                is_global = true
+                [c:/example.cs]
+                """,
+                """
+                is_global = true
+                [c:/test.cs]
+                """,
+                x => x.Replace("example", "test"));
+        }
+        else
+        {
+            Core(
+                """
+                is_global = true
+                [/c/example.cs]
+                """,
+                """
+                is_global = true
+                [/d/example.cs]
+                """,
+                x => x.Replace("/c", "/d"));
+
+            Core(
+                """
+                is_global = true
+                [/c/example.cs]
+                """,
+                """
+                is_global = true
+                [/c/test.cs]
+                """,
+                x => x.Replace("example", "test"));
+        }
 
         void Core(string content, string expected, Func<string, string> mapFunc)
         {

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -169,7 +169,7 @@ public sealed class RoslynUtilTests
                 """,
                 """
                 is_global = true
-                [d:\example.cs]
+                [d:/example.cs]
                 """,
                 x => x.Replace("c:", "d:"));
 

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -239,7 +240,7 @@ internal static class RoslynUtil
                 {
                     var mapped = pathMapFunc(line.Slice(1, index - 1).ToString());
                     builder.Append('[');
-                    builder.Append(mapped);
+                    builder.Append(EscapeEditorConfigSectionPath(mapped));
                     builder.Append(line.Slice(index));
                 }
             }
@@ -253,6 +254,22 @@ internal static class RoslynUtil
         });
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// The path used in a editor config section needs to be escaped on Windows.
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    internal static string EscapeEditorConfigSectionPath(string path)
+    {
+        // The \ on windows need to be escaped when emitted as part of a section header
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return path.Replace(@"\", @"/");
+        }
+
+        return path;
     }
 
     /// <summary>

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -25,6 +25,20 @@ using TraceReloggerLib;
 
 #pragma warning disable 8321
 
+var export = @"C:\Users\jaredpar\Downloads\customer-bug\.complog";
+if (Directory.Exists(export))
+{
+    Directory.Delete(export, recursive: true);
+}
+
+var sdkDirs = SdkUtil.GetSdkDirectories();
+using var reader = CompilerLogReader.Create(@"C:\Users\jaredpar\Downloads\customer-bug\msbuild.complog");
+var exportUtil = new ExportUtil(reader, includeAnalyzers: true);
+exportUtil.ExportAll(export, sdkDirs);
+
+
+
+/*
 using var reader = CompilerCallReaderUtil.Create("/home/jaredpar/code/msbuild/artifacts/log/Debug/Build.binlog", BasicAnalyzerKind.None);
 var compilerCall = reader
     .ReadAllCompilerCalls()
@@ -33,8 +47,9 @@ var data = reader.ReadCompilationData(compilerCall);
 var compilation = data.GetCompilationAfterGenerators();
 Console.WriteLine(compilation.AssemblyName);
 var diagnostics = compilation.GetDiagnostics();
+*/
 
-Bing();
+//Bing();
 void Bing()
 {
     var filePath = @"C:\Users\jaredpar\code\snrcode\msbuild.binlog";


### PR DESCRIPTION
This uses `/` when writing paths to editor config section headers. Windows previously was using `\` and that gets treated as a literal escape, not a directory separator.

closes #197