### PR TITLE
Change in memory loading to better reflect how roslyn loads analyzers / generators

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -89,7 +89,7 @@ jobs:
       run: dotnet run --framework net8.0 --project src/Basic.CompilerLog/Basic.CompilerLog.csproj create msbuild.binlog
 
     - name: Publish Compiler Log
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact }}
         path: msbuild.complog
@@ -101,14 +101,14 @@ jobs:
           directory: ${{ env.TEST_COVERAGE_PATH }}
 
     - name: Publish Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results
         path: ${{ env.TEST_RESULTS_PATH }}
 
     - name: Publish Test Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Test Artifacts ${{ matrix.os }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,9 +24,11 @@ jobs:
           - os: windows-latest
             artifact: windows.complog
             slash: \
+            test-results: test-results-windows
           - os: ubuntu-latest
             artifact: ubuntu.complog
             slash: /
+            test-results: test-results-linux
 
     env:
       TEST_ARTIFACTS_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test
@@ -104,7 +106,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results
+        name: ${{ matrix.test-results }}
         path: ${{ env.TEST_RESULTS_PATH }}
 
     - name: Publish Test Artifacts

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: test-results
+        artifact: test-results-(.*)/
         name: .NET Test Results
         path: '*.trx'
         reporter: dotnet-trx

--- a/src/Basic.CompilerLog.UnitTests/AssertEx.cs
+++ b/src/Basic.CompilerLog.UnitTests/AssertEx.cs
@@ -25,4 +25,36 @@ internal static class AssertEx
 
         Assert.True(emitResult.Success);
     }
+
+    /// <summary>
+    /// Use this over Assert.Equal for collections as the error messages are more actionable
+    /// </summary>
+    /// <param name="actual"></param>
+    internal static void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+    {
+        using var e1 = expected.GetEnumerator();
+        using var e2 = actual.GetEnumerator();
+
+        while (true)
+        {
+            if (!e1.MoveNext())
+            {
+                var b = e2.MoveNext();
+                if (b)
+                {
+
+                }
+                Assert.False(b);
+                break;
+            }
+
+            Assert.True(e2.MoveNext());
+            if (!e1.Current.Equals(e2.Current))
+            {
+
+            }
+
+            Assert.Equal(e1.Current, e2.Current);
+        }
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/AssertEx.cs
+++ b/src/Basic.CompilerLog.UnitTests/AssertEx.cs
@@ -39,21 +39,11 @@ internal static class AssertEx
         {
             if (!e1.MoveNext())
             {
-                var b = e2.MoveNext();
-                if (b)
-                {
-
-                }
-                Assert.False(b);
+                Assert.False(e2.MoveNext());
                 break;
             }
 
             Assert.True(e2.MoveNext());
-            if (!e1.Current.Equals(e2.Current))
-            {
-
-            }
-
             Assert.Equal(e1.Current, e2.Current);
         }
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -590,7 +590,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
         }
     }
 
-    public async IAsyncEnumerable<LogData> GetAllLogData(ITestOutputHelper testOutputHelper, BasicAnalyzerKind? kind = null)
+    public async IAsyncEnumerable<LogData> GetAllLogData(ITestOutputHelper testOutputHelper)
     {
         var start = DateTime.UtcNow;
         foreach (var lazyLogData in AllLogs)
@@ -621,6 +621,14 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                 logData = await tcs.Task;
             }
 
+            yield return logData;
+        }
+    }
+
+    public async IAsyncEnumerable<LogData> GetAllLogData(ITestOutputHelper testOutputHelper, BasicAnalyzerKind? kind = null)
+    {
+        await foreach (var logData in GetAllLogData(testOutputHelper))
+        {
             if (kind is not BasicAnalyzerKind.None || logData.SupportsNoneHost)
             {
                 yield return logData;

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -544,7 +544,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                     var scratchPath = Path.Combine(ScratchDirectory, Guid.NewGuid().ToString("N"));
                     Directory.CreateDirectory(scratchPath);
                     messageSink.OnDiagnosticMessage($"Starting {name} in {scratchPath}");
-                    RunDotnetCommand("new globaljson --sdk-version 9.0.100", scratchPath);
+                    RunDotnetCommand("new globaljson --sdk-version 9.0.100 --roll-forward minor", scratchPath);
                     action(scratchPath);
                     var binlogFilePath = Path.Combine(scratchPath, "msbuild.binlog");
                     Assert.True(File.Exists(binlogFilePath));

--- a/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
@@ -1,0 +1,55 @@
+namespace Basic.CompilerLog.UnitTests;
+
+using System.Runtime.InteropServices;
+using Basic.CompilerLog.Util;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+[Collection(CompilerLogCollection.Name)]
+public sealed class InMemoryLoaderTests : TestBase
+{
+    public CompilerLogFixture Fixture { get; }
+
+    public InMemoryLoaderTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, CompilerLogFixture fixture)
+        : base(testOutputHelper, testContextAccessor, nameof(CompilerLogReaderTests))
+    {
+        Fixture = fixture;
+    }
+
+#if NET
+
+    [Theory]
+    [InlineData("AbstractTypesShouldNotHaveConstructorsAnalyzer", LanguageNames.CSharp, 1)]
+    [InlineData("AbstractTypesShouldNotHaveConstructorsAnalyzer", null, 2)]
+    [InlineData("NotARealName", null, 0)]
+    public void AnalyzersForNetAnalyzers(string analyzerTypeName, string? language, int expectedCount)
+    {
+        using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath, BasicAnalyzerKind.InMemory);
+        var compilerCall = reader.ReadCompilerCall(0);
+        var compilerData = reader.ReadCompilationData(compilerCall);
+        var analyzerReference = compilerData.AnalyzerReferences.Single(x => x.Display == "Microsoft.CodeAnalysis.NetAnalyzers");
+        var analyzers = language is null
+            ? analyzerReference.GetAnalyzersForAllLanguages()
+            : analyzerReference.GetAnalyzers(language);
+        var specific = analyzers.Where(x => x.GetType().Name == analyzerTypeName);
+        Assert.Equal(expectedCount, specific.Count());
+    }
+
+    [Theory]
+    [InlineData("ComClassGenerator", LanguageNames.CSharp, 1)]
+    [InlineData("ComClassGenerator", null, 1)]
+    [InlineData("NotARealName", null, 0)]
+    public void GeneratorsForCom(string analyzerTypeName, string? language, int expectedCount)
+    {
+        using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath, BasicAnalyzerKind.InMemory);
+        var compilerCall = reader.ReadCompilerCall(0);
+        var compilerData = reader.ReadCompilationData(compilerCall);
+        var analyzerReference = compilerData.AnalyzerReferences.Single(x => x.Display == "Microsoft.Interop.ComInterfaceGenerator");
+        var generators = language is null
+            ? analyzerReference.GetGeneratorsForAllLanguages()
+            : analyzerReference.GetGenerators(language);
+        var specific = generators.Where(x => TestUtil.GetGeneratorType(x).Name == analyzerTypeName);
+        Assert.Equal(expectedCount, specific.Count());
+    }
+#endif
+}

--- a/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
@@ -45,7 +45,7 @@ public class LogReaderStateTests : TestBase
     public void CreateBasicAnalyzerHostBadKind()
     {
         using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath, BasicAnalyzerKind.None);
-        Assert.Throws<InvalidOperationException>(() => LogReaderState.CreateBasicAnalyzerHost(
+        Assert.Throws<InvalidOperationException>(() => BasicAnalyzerHost.Create(
             reader,
             (BasicAnalyzerKind)42,
             reader.ReadCompilerCall(0),

--- a/src/Basic.CompilerLog.UnitTests/SolutionFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionFixture.cs
@@ -67,7 +67,7 @@ public sealed class SolutionFixture : FixtureBase, IDisposable
         var binlogDir = Path.Combine(StorageDirectory, "binlogs");
         Directory.CreateDirectory(binlogDir);
 
-        RunDotnetCommand("new globaljson --sdk-version 9.0.100", StorageDirectory);
+        RunDotnetCommand("new globaljson --sdk-version 9.0.100 --roll-forward minor", StorageDirectory);
         RunDotnetCommand("dotnet new sln -n Solution", StorageDirectory);
 
         var builder = ImmutableArray.CreateBuilder<string>();

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -1,0 +1,21 @@
+
+using System.Reflection;
+
+namespace Basic.CompilerLog.UnitTests;
+
+internal static class TestUtil
+{
+    internal static Type GetGeneratorType(object obj)
+    {
+        var type = obj.GetType();
+        if (type.Name == "IncrementalGeneratorWrapper")
+        {
+            var prop = type.GetProperty(
+                "Generator",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!;
+            obj = prop.GetMethod!.Invoke(obj, null)!;
+        }
+
+        return obj.GetType();
+    }
+}

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -1,10 +1,17 @@
 
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace Basic.CompilerLog.UnitTests;
 
 internal static class TestUtil
 {
+    /// <summary>
+    /// Internally a <see cref="IIncrementalGenerator" /> is wrapped in a type called IncrementalGeneratorWrapper. 
+    /// This method will dig through that and return the original type.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
     internal static Type GetGeneratorType(object obj)
     {
         var type = obj.GetType();

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -5,6 +5,7 @@ using System.Windows.Markup;
 using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
@@ -258,6 +259,60 @@ public sealed class UsingAllCompilerLogTests : TestBase
             Assert.NotEmpty(solution.Projects);
         }
     }
+
+#if NET
+
+    /// <summary>
+    /// Ensure that the in memory loader finds the same set of analyzers that the 
+    /// on disk loader. The in memory loader has a lot of custom logic and need to
+    /// verify it stays in sync with the disk versions
+    /// </summary>
+    [Fact]
+    public async Task VerifyAnalyzerConsistency()
+    {
+        await foreach (var logData in Fixture.GetAllLogData(TestOutputHelper))
+        {
+            TestOutputHelper.WriteLine(logData.CompilerLogPath);
+            using var diskReader = CompilerLogReader.Create(logData.CompilerLogPath, BasicAnalyzerKind.OnDisk);
+            var diskDataList = diskReader.ReadAllCompilationData();
+            using var memoryReader = CompilerLogReader.Create(logData.CompilerLogPath, BasicAnalyzerKind.InMemory);
+            var memoryDataList = memoryReader.ReadAllCompilationData();
+            Assert.Equal(diskDataList.Count, memoryDataList.Count);
+            for (int i = 0; i < diskDataList.Count; i++)
+            {
+                var diskData = diskDataList[i];
+                var memoryData = memoryDataList[i];
+
+                var diskAnalyzers = diskData.AnalyzerReferences;
+                var memoryAnalyzers = memoryData.AnalyzerReferences;
+                Assert.Equal(diskAnalyzers.Length, memoryAnalyzers.Length);
+                for (int j = 0; j < diskAnalyzers.Length; j++)
+                {
+                    AssertCore(diskAnalyzers[j], memoryAnalyzers[j]);
+                }
+            }
+        }
+
+        void AssertCore(AnalyzerReference expected, AnalyzerReference actual)
+        {
+            var expectedAnalyzers = expected.GetAnalyzersForAllLanguages();
+            var actualAnalyzers = actual.GetAnalyzersForAllLanguages();
+
+            AssertEx.SequenceEqual(
+                expectedAnalyzers.Select(x => x.GetType().FullName).OrderBy(x => x),
+                actualAnalyzers.Select(x => x.GetType().FullName).OrderBy(x => x));
+
+            // Cannot test GetGeneratorsForAllLanguages here as it has a bug. The 
+            // de-dupe method not taking into account IncrementalGeneratorWrapper
+            var expectedGenerators = expected.GetGenerators(LanguageNames.CSharp);
+            var actualGenerators = actual.GetGenerators(LanguageNames.CSharp);
+            AssertEx.SequenceEqual(
+                expectedGenerators.Select(x => TestUtil.GetGeneratorType(x).FullName).OrderBy(x => x),
+                actualGenerators.Select(x => TestUtil.GetGeneratorType(x).FullName).OrderBy(x => x));
+        }
+    }
+
+#endif
 
     /// <summary>
     /// Ensure that our options round tripping code is correct and produces the same result as 

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -304,6 +304,9 @@ public sealed class UsingAllCompilerLogTests : TestBase
 
             // Cannot test GetGeneratorsForAllLanguages here as it has a bug. The 
             // de-dupe method not taking into account IncrementalGeneratorWrapper
+            //
+            // TODO: file a bug
+            // https://github.com/dotnet/roslyn/blob/99d8eeb69f19385838bf4e15dbe9bfcb50edc0eb/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs#L420
             var expectedGenerators = expected.GetGenerators(LanguageNames.CSharp);
             var actualGenerators = actual.GetGenerators(LanguageNames.CSharp);
             AssertEx.SequenceEqual(

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -305,7 +305,6 @@ public sealed class UsingAllCompilerLogTests : TestBase
             // Cannot test GetGeneratorsForAllLanguages here as it has a bug. The 
             // de-dupe method not taking into account IncrementalGeneratorWrapper
             //
-            // TODO: file a bug
             // https://github.com/dotnet/roslyn/blob/99d8eeb69f19385838bf4e15dbe9bfcb50edc0eb/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs#L420
             var expectedGenerators = expected.GetGenerators(LanguageNames.CSharp);
             var actualGenerators = actual.GetGenerators(LanguageNames.CSharp);

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
 
 #if NET
 using System.Runtime.Loader;
@@ -49,8 +50,9 @@ internal sealed class InMemoryLoader : AssemblyLoadContext
         foreach (var analyzer in analyzers)
         {
             var simpleName = Path.GetFileNameWithoutExtension(analyzer.FileName);
-            _map[simpleName] = provider.GetAssemblyBytes(analyzer.AssemblyData);
-            builder.Add(new BasicAnalyzerReference(new AssemblyName(simpleName), this, onDiagnostic));
+            var bytes = provider.GetAssemblyBytes(analyzer.AssemblyData);
+            _map[simpleName] = bytes;
+            builder.Add(new BasicAnalyzerReference(new AssemblyName(simpleName), bytes, this, onDiagnostic));
         }
 
         AnalyzerReferences = builder.MoveToImmutable();
@@ -80,6 +82,9 @@ internal sealed class InMemoryLoader : AssemblyLoadContext
         return null;
     }
 
+    public bool TryGetAssemblyBytes(AssemblyName assemblyName, [NotNullWhen(true)] out byte[]? bytes)
+        => _map.TryGetValue(assemblyName.Name!, out bytes);
+
     public void Dispose()
     {
         Unload();
@@ -97,7 +102,8 @@ internal sealed class InMemoryLoader
         var builder = ImmutableArray.CreateBuilder<AnalyzerReference>(analyzers.Count);
         foreach (var analyzer in analyzers)
         {
-            builder.Add(new BasicAnalyzerReference(new AssemblyName(analyzer.AssemblyIdentityData.AssemblyName), this, onDiagnostic));
+            var bytes = provider.GetAssemblyBytes(analyzer.AssemblyData);
+            builder.Add(new BasicAnalyzerReference(new AssemblyName(analyzer.AssemblyIdentityData.AssemblyName), bytes, this, onDiagnostic));
         }
 
         AnalyzerReferences = builder.MoveToImmutable();
@@ -209,14 +215,17 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
             isEnabledByDefault: true);
 
     internal AssemblyName AssemblyName { get; }
+    internal byte[] AssemblyBytes { get; }
     internal InMemoryLoader Loader { get; }
     internal Action<Diagnostic> OnDiagnostic { get; }
     public override object Id { get; } = Guid.NewGuid();
     public override string? FullPath => null;
+    public override string Display => AssemblyName.Name ?? "";
 
-    internal BasicAnalyzerReference(AssemblyName assemblyName, InMemoryLoader loader, Action<Diagnostic> onDiagnostic)
+    internal BasicAnalyzerReference(AssemblyName assemblyName, byte[] assemblyBytes, InMemoryLoader loader, Action<Diagnostic> onDiagnostic)
     {
         AssemblyName = assemblyName;
+        AssemblyBytes = assemblyBytes;
         Loader = loader;
         OnDiagnostic = onDiagnostic;
     }
@@ -249,74 +258,122 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
         return builder.ToImmutable();
     }
 
-    internal Type[] GetTypes(Assembly assembly)
+    internal List<Type> GetTypes(
+        string attributeNamespace,
+        string attributeName,
+        string? languageName,
+        Action<string?, Assembly, List<Type>, MetadataReader, TypeDefinition, CustomAttribute> action)
     {
         try
         {
-            return assembly.GetTypes();
+            var assembly = Loader.LoadFromAssemblyName(AssemblyName);
+            using var peReader = new PEReader(new MemoryStream(AssemblyBytes));
+            var list = new List<Type>();
+            var metadataReader = peReader.GetMetadataReader();
+            RoslynUtil.ForEachTypeWithAttribute(
+                metadataReader,
+                attributeNamespace,
+                attributeName,
+                (typeDef, attribute) => action(languageName, assembly, list, metadataReader, typeDef, attribute));
+
+            return list;
         }
         catch (Exception ex)
         {
-            var diagnostic = Diagnostic.Create(CannotLoadTypes, Location.None, assembly.FullName, ex.Message);
+            var diagnostic = Diagnostic.Create(CannotLoadTypes, Location.None, AssemblyName.FullName, ex.Message);
             OnDiagnostic(diagnostic);
-            return Array.Empty<Type>();
+            return [];
         }
     }
 
     internal void GetAnalyzers(ImmutableArray<DiagnosticAnalyzer>.Builder builder, string? languageName)
     {
-        var assembly = Loader.LoadFromAssemblyName(AssemblyName);
-        foreach (var type in GetTypes(assembly))
+        var attributeType = typeof(DiagnosticAnalyzerAttribute);
+        foreach (var type in GetTypes(attributeType.Namespace!, attributeType.Name, languageName, CoreAction))
         {
-            if (type.GetCustomAttributes(inherit: false) is { Length: > 0 } attributes)
+            builder.Add((DiagnosticAnalyzer)CreateInstance(type));
+        }
+
+        static void CoreAction(
+            string? languageName,
+            Assembly assembly,
+            List<Type> list,
+            MetadataReader metadataReader,
+            TypeDefinition typeDef,
+            CustomAttribute attribute)
+        {
+            if (languageName is null || RoslynUtil.IsLanguageName(metadataReader, attribute, languageName))
             {
-                foreach (var attribute in attributes)
+                var fqn = RoslynUtil.GetFullyQualifiedName(metadataReader, typeDef);
+                var type = assembly.GetType(fqn, throwOnError: false);
+                if (type is not null)
                 {
-                    if (attribute is DiagnosticAnalyzerAttribute d &&
-                        IsLanguageMatch(d.Languages))
+                    // When looking for "all languages" roslyn will include duplicates for all 
+                    // supported languages. This is undocumented behavior that we need to mimic
+                    //
+                    // https://github.com/dotnet/roslyn/blob/329bb90e91561c8f26e4f8aeae17be1697db850b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs#L111
+                    var count = languageName is not null
+                        ? 1
+                        : RoslynUtil.CountLanguageNames(metadataReader, attribute);
+                    for (int i = 0; i < count; i++)
                     {
-                        builder.Add((DiagnosticAnalyzer)CreateInstance(type));
-                        break;
+                        list.Add(type);
                     }
                 }
             }
         }
-
-        bool IsLanguageMatch(string[] languages) =>
-            languageName is null || languages.Contains(languageName);
     }
 
     internal void GetGenerators(ImmutableArray<ISourceGenerator>.Builder builder, string? languageName)
     {
-        var assembly = Loader.LoadFromAssemblyName(AssemblyName);
-        foreach (var type in GetTypes(assembly))
+        var attributeType = typeof(GeneratorAttribute);
+        foreach (var type in GetTypes(attributeType.Namespace!, attributeType.Name, languageName, CoreAction))
         {
-            if (type.GetCustomAttributes(inherit: false) is { Length: > 0 } attributes)
+            var generator = CreateInstance(type);
+            if (generator is ISourceGenerator sg)
             {
-                foreach (var attribute in attributes)
-                {
-                    if (attribute is GeneratorAttribute g &&
-                        IsLanguageMatch(g.Languages))
-                    {
-                        var generator = CreateInstance(type);
-                        if (generator is ISourceGenerator sg)
-                        {
-                            builder.Add(sg);
-                        }
-                        else
-                        {
-                            IIncrementalGenerator ig = (IIncrementalGenerator)generator;
-                            builder.Add(ig.AsSourceGenerator());
-                        }
-
-                        break;
-                    }
-                }
+                builder.Add(sg);
+            }
+            else
+            {
+                IIncrementalGenerator ig = (IIncrementalGenerator)generator;
+                builder.Add(ig.AsSourceGenerator());
             }
         }
 
-        bool IsLanguageMatch(string[] languages) =>
-            languageName is null || languages.Contains(languageName);
+        static void CoreAction(
+            string? languageName,
+            Assembly assembly,
+            List<Type> list,
+            MetadataReader metadataReader,
+            TypeDefinition typeDef,
+            CustomAttribute attribute)
+        {
+            var match = false;
+            if (languageName is null)
+            {
+                match = true;
+            }
+            else if (RoslynUtil.IsEmptyAttribute(metadataReader, attribute))
+            {
+                // The empty attribute is an implicit C# 
+                match = languageName == LanguageNames.CSharp;
+            }
+            else
+            {
+                match = RoslynUtil.IsLanguageName(metadataReader, attribute, languageName);
+            }
+
+            if (match)
+            {
+                var fqn = RoslynUtil.GetFullyQualifiedName(metadataReader, typeDef);
+                var type = assembly.GetType(fqn, throwOnError: false);
+                if (type is not null)
+                {
+                    list.Add(type);
+                }
+            }
+        }
     }
 
     private static object CreateInstance(Type type)

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -82,9 +82,6 @@ internal sealed class InMemoryLoader : AssemblyLoadContext
         return null;
     }
 
-    public bool TryGetAssemblyBytes(AssemblyName assemblyName, [NotNullWhen(true)] out byte[]? bytes)
-        => _map.TryGetValue(assemblyName.Name!, out bytes);
-
     public void Dispose()
     {
         Unload();
@@ -305,7 +302,7 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
             if (languageName is null || RoslynUtil.IsLanguageName(metadataReader, attribute, languageName))
             {
                 var fqn = RoslynUtil.GetFullyQualifiedName(metadataReader, typeDef);
-                var type = assembly.GetType(fqn, throwOnError: false);
+                var type = assembly.GetType(fqn, throwOnError: true);
                 if (type is not null)
                 {
                     // When looking for "all languages" roslyn will include duplicates for all 

--- a/src/Basic.CompilerLog.Util/LogReaderState.cs
+++ b/src/Basic.CompilerLog.Util/LogReaderState.cs
@@ -134,7 +134,7 @@ public sealed class LogReaderState : IDisposable
             }
         }
 
-        basicAnalyzerHost = CreateBasicAnalyzerHost(dataProvider, kind, compilerCall, analyzers);
+        basicAnalyzerHost = BasicAnalyzerHost.Create(dataProvider, kind, compilerCall, analyzers);
         BasicAnalyzerHosts.Add(basicAnalyzerHost);
 
         if (key is not null)
@@ -153,44 +153,6 @@ public sealed class LogReaderState : IDisposable
                 _ = builder.AppendLine($"{analyzer.Mvid}");
             }
             return builder.ToString();
-        }
-    }
-
-    internal static BasicAnalyzerHost CreateBasicAnalyzerHost(
-        IBasicAnalyzerHostDataProvider dataProvider,
-        BasicAnalyzerKind kind,
-        CompilerCall compilerCall,
-        List<AnalyzerData> analyzers)
-    {
-        return kind switch
-        {
-            BasicAnalyzerKind.OnDisk => new BasicAnalyzerHostOnDisk(dataProvider, analyzers),
-            BasicAnalyzerKind.InMemory => new BasicAnalyzerHostInMemory(dataProvider, analyzers),
-            BasicAnalyzerKind.None => CreateNone(analyzers),
-            _ => throw new InvalidOperationException()
-        };
-
-        BasicAnalyzerHostNone CreateNone(List<AnalyzerData> analyzers)
-        {
-            if (analyzers.Count == 0)
-            {
-                return new BasicAnalyzerHostNone();
-            }
-
-            if (!dataProvider.HasAllGeneratedFileContent(compilerCall))
-            {
-                return new("Generated files not available in the PDB");
-            }
-
-            try
-            {
-                var generatedSourceTexts = dataProvider.ReadAllGeneratedSourceTexts(compilerCall);
-                return new BasicAnalyzerHostNone(generatedSourceTexts);
-            }
-            catch (Exception ex)
-            {
-                return new BasicAnalyzerHostNone(ex.Message);
-            }
         }
     }
 }


### PR DESCRIPTION
This change brings the in memory loader in line with how `AnalyzerFileReference` processes analyzers and generators. The code now uses `System.Reflection.Metadata` to scan for analyzer types in the assembly and then load only those into the process. This allows analyzer assemblies that have missing references that don't impact analyzers directly to still function. It also reduces the number of first chance exceptions generated in that scenario which significantly improves debugging. 