### PR TITLE
Fix handling analyzers with bad definitions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,11 +13,9 @@
             "program": "${workspaceFolder}/artifacts/bin/Basic.CompilerLog/debug_net9.0/Basic.CompilerLog.dll",
             "args": [
                 "replay",
-                "/home/jaredpar/code/msbuild/artifacts/log/Debug/Build.binlog",
-                "-p",
-                "StringTools.UnitTests.csproj",
-                "-n"],
-            "cwd": "/home/jaredpar/code/msbuild/artifacts/log/Debug",
+                "C:/Users/jaredpar/temp/console/build.complog"
+            ],
+            "cwd": "${workspaceFolder}/artifacts/",
             // "cwd": "${workspaceFolder}/src/Basic.CompilerLog",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
+++ b/src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="xunit.v3" />
     <ProjectReference Include="..\Basic.CompilerLog.Util\Basic.CompilerLog.Util.csproj" />
     <ProjectReference Include="..\Basic.CompilerLog\Basic.CompilerLog.csproj" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Basic.Reference.Assemblies.Net60" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" />
     <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
@@ -81,7 +81,7 @@ public sealed class BasicAnalyzerHostTests : TestBase
         var compilation = CSharpCompilation.Create(
             "example",
             [],
-            Basic.Reference.Assemblies.Net60.References.All);
+            Basic.Reference.Assemblies.Net80.References.All);
         var driver = CSharpGeneratorDriver.Create([host.Generator!]);
         driver.RunGeneratorsAndUpdateCompilation(compilation, out var compilation2, out var diagnostics, CancellationToken);
         Assert.Empty(diagnostics);

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
     <_RoslynVersion>4.12.0</_RoslynVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net60" Version="1.8.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -386,7 +386,7 @@ static void RoslynScratch()
     var compilation = CSharpCompilation.Create(
         "scratch",
         new[] { syntaxTree },
-        Basic.Reference.Assemblies.Net60.References.All);
+        Basic.Reference.Assemblies.Net80.References.All);
 
     var context = compilation.GetSemanticModel(syntaxTree);
     var token = syntaxTree

--- a/src/Scratch/Scratch.csproj
+++ b/src/Scratch/Scratch.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Basic.CompilerLog\Basic.CompilerLog.csproj" />
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
-    <PackageReference Include="Basic.Reference.Assemblies.Net60" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" />
   </ItemGroup>


### PR DESCRIPTION
This makes the loader tolerant of analyzers / generators that have incorrect definitions. For example being attributed as an analyzer but not actually deriving from the correct type

closes #212