### PR TITLE
Tolerance for missing files

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -123,6 +123,7 @@ jobs:
     name: Produce Test Report
     needs: build
     runs-on: ubuntu-latest
+    if: always()
     steps:
     - uses: dorny/test-reporter@v1
       with:

--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -171,7 +171,8 @@ public sealed class CompilationDataTests : TestBase
             data.EmitData,
             data.AdditionalTexts,
             host,
-            data.AnalyzerConfigOptionsProvider);
+            data.AnalyzerConfigOptionsProvider,
+            creationDiagnostics: []);
         Assert.NotEmpty(await data.GetAllDiagnosticsAsync(CancellationToken));
     }
 
@@ -199,7 +200,8 @@ public sealed class CompilationDataTests : TestBase
                 data.EmitData,
                 data.AdditionalTexts,
                 host,
-                data.AnalyzerConfigOptionsProvider);
+                data.AnalyzerConfigOptionsProvider,
+                creationDiagnostics: []);
             _ = data.GetCompilationAfterGenerators(out var diagnostics, cancellationToken);
             Assert.NotEmpty(diagnostics);
         });

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -14,8 +14,12 @@ public sealed class CompilerLogBuilderTests : TestBase
         Fixture = fixture;
     }
 
+    /// <summary>
+    /// We should be able to create log files that are resilient to artifacts missing on disk. Basically we can create 
+    /// a <see cref="CompilationData"/> for this scenario, it will have diagnostics.
+    /// </summary>
     [Fact]
-    public void AddMissingFile()
+    public void MissingFileSourceLink()
     {
         using var stream = new MemoryStream();
         using var builder = new CompilerLogBuilder(stream, new());
@@ -23,7 +27,7 @@ public sealed class CompilerLogBuilderTests : TestBase
 
         var compilerCall = BinaryLogUtil.ReadAllCompilerCalls(binlogStream).First(x => x.IsCSharp);
         compilerCall = compilerCall.WithArguments(["/sourcelink:does-not-exist.txt"]);
-        Assert.Throws<Exception>(() => builder.AddFromDisk(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall)));
+        builder.AddFromDisk(compilerCall, BinaryLogUtil.ReadCommandLineArgumentsUnsafe(compilerCall));
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderExTests.cs
@@ -103,7 +103,7 @@ public sealed class CompilerLogReaderExTests : TestBase
         var diagnostics = new List<string>();
         var filePath = Path.Combine(RootDirectory, fileName);
         var prefix = option is null ? "" : $"/{option}:";
-        using var reader = ConvertConsole(x => x.WithAdditionalArguments([$"{prefix}{filePath}"]), diagnostics: diagnostics);
+        using var reader = ConvertConsole(x => x.WithAdditionalArguments([$"{prefix}{filePath}"]), BasicAnalyzerKind.None, diagnostics);
         Assert.Equal([RoslynUtil.GetMissingFileDiagnosticMessage(filePath)], diagnostics);
         var compilationData = reader.ReadAllCompilationData().Single();
         if (hasDiagnostics)

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -443,13 +443,13 @@ public sealed class CompilerLogReaderTests : TestBase
         RunDotNet("build -bl:build.binlog -nr:false", dir);
 
         var binlogFilePath = Path.Combine(dir, "build.binlog");
-        using var binlogReader = BinaryLogReader.Create(binlogFilePath);
+        using var binlogReader = BinaryLogReader.Create(binlogFilePath, BasicAnalyzerKind.None);
         await Core(binlogReader, CancellationToken);
         binlogReader.Dispose();
 
         var complogFilePath = Path.Combine(dir, "build.complog");
         CompilerLogUtil.ConvertBinaryLog(binlogFilePath, complogFilePath);
-        using var complogReader = CompilerLogReader.Create(complogFilePath);
+        using var complogReader = CompilerLogReader.Create(complogFilePath, BasicAnalyzerKind.None);
         await Core(complogReader, CancellationToken);
 
         static async Task Core(ICompilerCallReader reader, CancellationToken cancellationToken)

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -17,6 +17,7 @@ using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Basic.CompilerLog.UnitTests;
 
@@ -51,7 +52,7 @@ public sealed class CompilerLogReaderTests : TestBase
         using var reader = CompilerLogReader.Create(Path.Combine(RootDirectory, "msbuild.binlog"));
         var extraData = reader.ReadAllRawContent(0).Single(x => Path.GetFileName(x.OriginalFilePath) == fileName);
         Assert.Equal("84C9FAFCF8C92F347B96D26B149295128B08B07A3C4385789FE4758A2B520FDE", extraData.ContentHash);
-        var contentBytes = reader.GetContentBytes(extraData.ContentHash);
+        var contentBytes = reader.GetContentBytes(extraData.ContentHash!);
         Assert.Equal(content, DefaultEncoding.GetString(contentBytes));
     }
 
@@ -391,7 +392,7 @@ public sealed class CompilerLogReaderTests : TestBase
         var data = reader.ReadCompilationData(0);
         var compilation = data.GetCompilationAfterGenerators(out var diagnostics, CancellationToken);
         Assert.Single(diagnostics);
-        Assert.Equal(BasicAnalyzerHostNone.CannotReadGeneratedFiles.Id, diagnostics[0].Id);
+        Assert.Equal(RoslynUtil.CannotReadGeneratedFilesDiagnosticDescriptor.Id, diagnostics[0].Id);
     }
 
     [Theory]
@@ -419,6 +420,61 @@ public sealed class CompilerLogReaderTests : TestBase
     {
         using var reader = CompilerLogReader.Create(Fixture.Console.Value.CompilerLogPath);
         Assert.Throws<ArgumentException>(() => reader.ReadCompilationData(index));
+    }
+
+    [Fact]
+    public async Task ReadCompilationDataMissingAdditionalFiles()
+    {
+        var dir = Root.NewDirectory("missing-additional-files");
+        RunDotNet("new classlib --name example -o .", dir);
+        SetProjectFileContent("""
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <NoWarn>$(NoWarn);CS8933</NoWarn>
+                </PropertyGroup>
+                <ItemGroup>
+                    <AdditionalFiles Include="additional.txt" />
+                </ItemGroup>
+            </Project>
+            """, dir);
+        RunDotNet("build -bl:build.binlog -nr:false", dir);
+
+        var binlogFilePath = Path.Combine(dir, "build.binlog");
+        using var binlogReader = BinaryLogReader.Create(binlogFilePath);
+        await Core(binlogReader, CancellationToken);
+        binlogReader.Dispose();
+
+        var complogFilePath = Path.Combine(dir, "build.complog");
+        CompilerLogUtil.ConvertBinaryLog(binlogFilePath, complogFilePath);
+        using var complogReader = CompilerLogReader.Create(complogFilePath);
+        await Core(complogReader, CancellationToken);
+
+        static async Task Core(ICompilerCallReader reader, CancellationToken cancellationToken)
+        {
+            var compilerCall = reader.ReadAllCompilerCalls().Single();
+            var compilationData = reader.ReadCompilationData(compilerCall);
+            var diagnostics = compilationData.GetDiagnostics();
+
+            // This may seem counter intuitive but the compiler does not issue an error on a missing 
+            // additional file. The error only happens if something tries to read the file
+            Assert.Empty(diagnostics);
+
+            diagnostics = await compilationData.GetAllDiagnosticsAsync(cancellationToken);
+            Assert.Empty(diagnostics);
+
+            var additionalText = (BasicAdditionalText)compilationData.AdditionalTexts.Single();
+            Assert.Null(additionalText.GetText());
+            Assert.Single(additionalText.Diagnostics);
+            Assert.Equal(RoslynUtil.CannotReadFileDiagnosticDescriptor, additionalText.Diagnostics[0].Descriptor);
+
+            // Now that the text is observed to be empty the diagnostic should show up
+            diagnostics = await compilationData.GetAllDiagnosticsAsync(cancellationToken);
+            Assert.Single(diagnostics);
+            Assert.Equal(RoslynUtil.CannotReadFileDiagnosticDescriptor, additionalText.Diagnostics[0].Descriptor);
+        }
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -478,8 +478,10 @@ public sealed class ExportUtilTests : TestBase
         ExportUtil.ExportRsp(reader.ReadCompilerCall(0), writer);
         Assert.Contains(fileName, writer.ToString());
 
+#if NET
         using var scratchDir = new TempDir("export test");
         var exportUtil = new ExportUtil(reader, includeAnalyzers: true);
         exportUtil.ExportAll(scratchDir.DirectoryPath, SdkUtil.GetSdkDirectories());
+#endif
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -110,7 +110,7 @@ public sealed class ExportUtilTests : TestBase
             if (runBuild)
             {
                 // Now run the generated build.cmd and see if it succeeds;
-                var buildResult = RunBuildCmd(tempDir.DirectoryPath);
+                var buildResult = TestUtil.RunBuildCmd(tempDir.DirectoryPath);
                 testOutputHelper.WriteLine(buildResult.StandardOut);
                 testOutputHelper.WriteLine(buildResult.StandardError);
                 verifyBuildResult?.Invoke(buildResult);

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -461,12 +461,8 @@ public sealed class ExportUtilTests : TestBase
     }
 
     [Theory]
-    [InlineData("keyfile", "does-not-exist.snk")]
-    [InlineData("embed", "data.txt")]
-    [InlineData("win32manifest", "data.manifest")]
-    [InlineData("analyzerconfig", "data.config")]
-    [InlineData(null, "data.cs")]
-    public void MissingFiles(string? option, string fileName)
+    [MemberData(nameof(GetMissingFileArguments))]
+    public void MissingFiles(string? option, string fileName, bool _)
     {
         var diagnostics = new List<string>();
         var filePath = Path.Combine(RootDirectory, fileName);
@@ -478,10 +474,12 @@ public sealed class ExportUtilTests : TestBase
             diagnostics: diagnostics);
         Assert.Equal([RoslynUtil.GetMissingFileDiagnosticMessage(filePath)], diagnostics);
 
-        using var scratchDir = new TempDir("export test");
-        var exportUtil = new ExportUtil(reader, includeAnalyzers: true);
         using var writer = new StringWriter();
         ExportUtil.ExportRsp(reader.ReadCompilerCall(0), writer);
         Assert.Contains(fileName, writer.ToString());
+
+        using var scratchDir = new TempDir("export test");
+        var exportUtil = new ExportUtil(reader, includeAnalyzers: true);
+        exportUtil.ExportAll(scratchDir.DirectoryPath, SdkUtil.GetSdkDirectories());
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/Extensions.cs
+++ b/src/Basic.CompilerLog.UnitTests/Extensions.cs
@@ -40,9 +40,8 @@ internal static class Extensions
         }
     }
 
-    internal static CompilerCall WithArguments(this CompilerCall compilerCall, IReadOnlyCollection<string> arguments)
-    {
-        return new CompilerCall(
+    internal static CompilerCall WithArguments(this CompilerCall compilerCall, IReadOnlyCollection<string> arguments) =>
+        new CompilerCall(
             compilerCall.ProjectFilePath,
             compilerCall.CompilerFilePath,
             compilerCall.Kind,
@@ -50,6 +49,11 @@ internal static class Extensions
             compilerCall.IsCSharp,
             new Lazy<IReadOnlyCollection<string>>(() => arguments),
             compilerCall.OwnerState);
+
+    internal static CompilerCall WithAdditionalArguments(this CompilerCall compilerCall, IReadOnlyCollection<string> arguments)
+    {
+        string[] args = [.. compilerCall.GetArguments(), .. arguments];
+        return compilerCall.WithArguments(args);
     }
 
     internal static CompilerCall WithOwner(this CompilerCall compilerCall, object? ownerState)

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -244,7 +244,9 @@ public sealed class ProgramTests : TestBase
     [Fact]
     public void CreateOverRemovedProject()
     {
-        Assert.Equal(Constants.ExitFailure, RunCompLog($"create {Fixture.RemovedBinaryLogPath}"));
+        var (exitCode, output) = RunCompLogEx($"create {Fixture.RemovedBinaryLogPath}");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Contains(RoslynUtil.GetMissingFileDiagnosticMessage(""), output);
     }
 
     [Theory]
@@ -480,7 +482,7 @@ public sealed class ProgramTests : TestBase
 
             // Now run the generated build.cmd and see if it succeeds;
             var exportPath = Path.Combine(exportDir.DirectoryPath, "console");
-            var buildResult = RunBuildCmd(exportPath);
+            var buildResult = TestUtil.RunBuildCmd(exportPath);
             Assert.True(buildResult.Succeeded);
 
             // Check that the RSP file matches the analyzer intent

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -159,7 +159,7 @@ public abstract class TestBase : IDisposable
         BasicAnalyzerKind? basicAnalyzerKind = null,
         List<string>? diagnostics = null)
     {
-        var reader = CompilerCallReaderUtil.Create(logFilePath, basicAnalyzerKind, State);
+        using var reader = CompilerCallReaderUtil.Create(logFilePath, basicAnalyzerKind, State);
         var compilerCall = reader
             .ReadAllCompilerCalls(predicate)
             .Single();

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -139,22 +139,11 @@ public abstract class TestBase : IDisposable
         Assert.Equal(0, result.ExitCode);
     }
 
-    protected void AddProjectProperty(string property, string? workingDirectory = null)
-    {
-        workingDirectory ??= RootDirectory;
-        var projectFile = Directory.EnumerateFiles(workingDirectory, "*proj").Single();
-        var lines = File.ReadAllLines(projectFile);
-        using var writer = new StreamWriter(projectFile, append: false);
-        foreach (var line in lines)
-        {
-            if (line.Contains("</PropertyGroup>"))
-            {
-                writer.WriteLine(property);
-            }
+    protected void AddProjectProperty(string property, string? workingDirectory = null) =>
+        TestUtil.AddProjectProperty(property, workingDirectory ?? RootDirectory);
 
-            writer.WriteLine(line);
-        }
-    }
+    protected void SetProjectFileContent(string content, string? workingDirectory = null) =>
+        TestUtil.SetProjectFileContent(content, workingDirectory ?? RootDirectory);
 
     protected string GetBinaryLogFullPath(string? workingDirectory = null) =>
         Path.Combine(workingDirectory ?? RootDirectory, "msbuild.binlog");
@@ -180,14 +169,6 @@ public abstract class TestBase : IDisposable
         stream.Position = 0;
         return CompilerLogReader.Create(stream, state, leaveOpen: false);
     }
-
-    /// <summary>
-    /// Run the build.cmd / .sh generated from an export command
-    /// </summary>
-    internal static ProcessResult RunBuildCmd(string directory) =>
-        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-         ? ProcessUtil.Run("cmd", args: "/c build.cmd", workingDirectory: directory)
-         : ProcessUtil.Run(Path.Combine(directory, "build.sh"), args: "", workingDirectory: directory);
 
     protected void RunInContext<T>(T state, Action<ITestOutputHelper, T, CancellationToken> action, [CallerMemberName] string? testMethod = null)
     {

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xaml;
 using Xunit;
 using Xunit.Sdk;
 
@@ -48,7 +49,7 @@ public abstract class TestBase : IDisposable
     {
         foreach (BasicAnalyzerKind e in Enum.GetValues(typeof(BasicAnalyzerKind)))
         {
-            yield return new object[] { e };
+            yield return [e];
         }
     }
 
@@ -58,12 +59,12 @@ public abstract class TestBase : IDisposable
     /// <returns></returns>
     public static IEnumerable<object[]> GetSupportedBasicAnalyzerKinds()
     {
-        yield return new object[] { BasicAnalyzerKind.None };
-        yield return new object[] { BasicAnalyzerKind.OnDisk };
+        yield return [BasicAnalyzerKind.None];
+        yield return [BasicAnalyzerKind.OnDisk];
 
         if (IsNetCore)
         {
-            yield return new object[] { BasicAnalyzerKind.InMemory };
+            yield return [BasicAnalyzerKind.InMemory];
         }
     }
 
@@ -74,13 +75,28 @@ public abstract class TestBase : IDisposable
     /// <returns></returns>
     public static IEnumerable<object[]> GetSimpleBasicAnalyzerKinds()
     {
-        yield return new object[] { BasicAnalyzerKind.None };
+        yield return [BasicAnalyzerKind.None];
 
         if (IsNetCore)
         {
-            yield return new object[] { BasicAnalyzerKind.OnDisk };
-            yield return new object[] { BasicAnalyzerKind.InMemory };
+            yield return [BasicAnalyzerKind.OnDisk];
+            yield return [BasicAnalyzerKind.InMemory];
         }
+    }
+
+    /// <summary>
+    /// This captures the set of "missing" files that we need to be tolerant of in our 
+    /// reading and creation of compiler logs.
+    /// </summary>
+    public static IEnumerable<object?[]> GetMissingFileArguments()
+    {
+        yield return ["keyfile", "does-not-exist.snk", false]; // key file isn't noticed until emit
+        yield return ["embed", "data.txt", true];
+        yield return ["win32manifest", "data.manifest", false]; // manifest isn't noticed until emit
+        yield return ["win32res", "data.res", true]; 
+        yield return ["sourcelink", "data.link", true];
+        yield return ["analyzerconfig", "data.config", true];
+        yield return [null, "data.cs", true];
     }
 
     protected TestBase(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor, string name)

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -1,6 +1,10 @@
 
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
 using Microsoft.CodeAnalysis;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Basic.CompilerLog.UnitTests;
 
@@ -24,5 +28,41 @@ internal static class TestUtil
         }
 
         return obj.GetType();
+    }
+
+    /// <summary>
+    /// Run the build.cmd / .sh generated from an export command
+    /// </summary>
+    internal static ProcessResult RunBuildCmd(string directory) =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+         ? ProcessUtil.Run("cmd", args: "/c build.cmd", workingDirectory: directory)
+         : ProcessUtil.Run(Path.Combine(directory, "build.sh"), args: "", workingDirectory: directory);
+
+    internal static string GetProjectFile(string directory) =>
+        Directory.EnumerateFiles(directory, "*proj").Single();
+
+    /// <summary>
+    /// Add a project property to the project file in the current directory
+    /// </summary>
+    internal static void AddProjectProperty(string property, string directory)
+    {
+        var projectFile = GetProjectFile(directory);
+        var lines = File.ReadAllLines(projectFile);
+        using var writer = new StreamWriter(projectFile, append: false);
+        foreach (var line in lines)
+        {
+            if (line.Contains("</PropertyGroup>"))
+            {
+                writer.WriteLine(property);
+            }
+
+            writer.WriteLine(line);
+        }
+    }
+
+    internal static void SetProjectFileContent(string content, string directory)
+    {
+        var projectFile = GetProjectFile(directory);
+        File.WriteAllText(projectFile, content);
     }
 }

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -272,6 +272,15 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
                 return null;
             }
 
+            if (!File.Exists(filePath))
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    RoslynUtil.CannotReadFileDiagnosticDescriptor,
+                    Location.None,
+                    filePath));
+                return null;
+            }
+
             var bytes = File.ReadAllBytes(filePath);
             return new MemoryStream(bytes);
         }
@@ -286,6 +295,15 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
             var list = new List<EmbeddedText>(args.EmbeddedFiles.Length);
             foreach (var item in args.EmbeddedFiles)
             {
+                if (!File.Exists(item.Path))
+                {
+                    diagnostics.Add(Diagnostic.Create(
+                        RoslynUtil.CannotReadFileDiagnosticDescriptor,
+                        Location.None,
+                        item.Path));
+                    continue;
+                }
+
                 var sourceText = RoslynUtil.GetSourceText(item.Path, args.ChecksumAlgorithm, canBeEmbedded: true);
                 var embeddedText = EmbeddedText.FromSource(item.Path, sourceText);
                 list.Add(embeddedText);

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -159,6 +159,7 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         CheckOwnership(compilerCall);
         var (compilerCallData, args) = ReadCompilerCallDataCore(compilerCall);
 
+        var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
         var references = GetReferences();
         var sourceTexts = GetSourceTexts();
         var additionalTexts = GetAdditionalTexts();
@@ -182,7 +183,8 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
                 args.EmitOptions,
                 emitData,
                 basicAnalyzerHost,
-                PathNormalizationUtil.Empty);
+                PathNormalizationUtil.Empty,
+                diagnostics.ToImmutable());
         }
 
         VisualBasicCompilationData GetVisualBasic()
@@ -199,7 +201,8 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
                 args.EmitOptions,
                 emitData,
                 basicAnalyzerHost,
-                PathNormalizationUtil.Empty);
+                PathNormalizationUtil.Empty,
+                diagnostics.ToImmutable());
         }
 
         List<(SourceText SourceText, string Path)> GetAnalyzerConfigs() => 
@@ -219,11 +222,20 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         List<(SourceText SourceText, string Path)> GetSourceTexts() =>
             GetSourceTextsFromPaths(args.SourceFiles.Select(x => x.Path), args.SourceFiles.Length, args.ChecksumAlgorithm);
 
-        static List<(SourceText SourceText, string Path)> GetSourceTextsFromPaths(IEnumerable<string> filePaths, int count, SourceHashAlgorithm checksumAlgorithm)
+        List<(SourceText SourceText, string Path)> GetSourceTextsFromPaths(IEnumerable<string> filePaths, int count, SourceHashAlgorithm checksumAlgorithm)
         {
             var list = new List<(SourceText, string)>(capacity: count);
             foreach (var filePath in filePaths)
             {
+                if (!File.Exists(filePath))
+                {
+                    diagnostics.Add(Diagnostic.Create(
+                        RoslynUtil.CannotReadFileDiagnosticDescriptor,
+                        Location.None,
+                        filePath));
+                    continue;
+                }
+
                 var sourceText = RoslynUtil.GetSourceText(filePath, checksumAlgorithm, canBeEmbedded: false);
                 list.Add((sourceText, filePath));
             }
@@ -235,10 +247,7 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
             var builder = ImmutableArray.CreateBuilder<AdditionalText>(args.AdditionalFiles.Length);
             foreach (var additionalFile in args.AdditionalFiles)
             {
-                var sourceText = RoslynUtil.GetSourceText(additionalFile.Path, args.ChecksumAlgorithm, canBeEmbedded: false);
-                var additionalText = new BasicAdditionalTextFile(
-                    additionalFile.Path,
-                    sourceText);
+                var additionalText = new BasicAdditionalTextFile(additionalFile.Path, args.ChecksumAlgorithm);
                 builder.Add(additionalText);
             }
             return builder.MoveToImmutable();

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -48,6 +48,11 @@ public abstract class CompilationData
     public EmitOptions EmitOptions { get; }
     public ParseOptions ParseOptions { get; }
 
+    /// <summary>
+    /// Diagnostics that resulted from rehydrating the compilation.
+    /// </summary>
+    public ImmutableArray<Diagnostic> CreationDiagnostics { get; }
+
     public CompilationOptions CompilationOptions => Compilation.Options;
     public bool IsCSharp => Compilation is CSharpCompilation;
     public bool IsVisualBasic => !IsCSharp;
@@ -92,7 +97,8 @@ public abstract class CompilationData
         EmitData emitData,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
-        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
+        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider,
+        ImmutableArray<Diagnostic> creationDiagnostics)
     {
         CompilerCall = compilerCall;
         Compilation = compilation;
@@ -103,6 +109,7 @@ public abstract class CompilationData
         BasicAnalyzerHost = basicAnalyzerHost;
         AnalyzerReferences = basicAnalyzerHost.AnalyzerReferences;
         AnalyzerConfigOptionsProvider = analyzerConfigOptionsProvider;
+        CreationDiagnostics = creationDiagnostics;
     }
 
     public ImmutableArray<DiagnosticAnalyzer> GetAnalyzers()
@@ -142,9 +149,14 @@ public abstract class CompilationData
         diagnostics = tuple.Item2;
 
         // Now that analyzers have completed running add any diagnostics the host has captured
-        if (BasicAnalyzerHost.GetDiagnostics() is { Count: > 0} list)
+        if (BasicAnalyzerHost.GetDiagnostics() is { Count: > 0 } list)
         {
             diagnostics = diagnostics.AddRange(list);
+        }
+
+        if (CreationDiagnostics.Length > 0)
+        {
+            diagnostics = diagnostics.AddRange(CreationDiagnostics);
         }
 
         return tuple.Item1;
@@ -215,6 +227,14 @@ public abstract class CompilationData
         {
             var cwa = new CompilationWithAnalyzers(compilation, GetAnalyzers(), AnalyzerOptions);
             diagnostics = await cwa.GetAllDiagnosticsAsync().ConfigureAwait(false);
+        }
+
+        foreach (var additionalText in AdditionalTexts)
+        {
+            if (additionalText is BasicAdditionalText { Diagnostics.Length: > 0 } basicAdditionalText)
+            {
+                diagnostics = diagnostics.AddRange(basicAdditionalText.Diagnostics);
+            }
         }
 
         return diagnostics.AddRange(hostDiagnostics);
@@ -360,8 +380,9 @@ public abstract class CompilationData<TCompilation, TParseOptions> : Compilation
         EmitData emitData,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
-        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
-        :base(compilerCall, compilation, parseOptions, emitOptions, emitData, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
+        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider,
+        ImmutableArray<Diagnostic> creationDiagnostics)
+        :base(compilerCall, compilation, parseOptions, emitOptions, emitData, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider, creationDiagnostics)
     {
         
     }
@@ -377,8 +398,9 @@ public sealed class CSharpCompilationData : CompilationData<CSharpCompilation, C
         EmitData emitData,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
-        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
-        :base(compilerCall, compilation, parseOptions, emitOptions, emitData, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
+        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider,
+        ImmutableArray<Diagnostic> creationDiagnostics)
+        :base(compilerCall, compilation, parseOptions, emitOptions, emitData, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider, creationDiagnostics)
     {
 
     }
@@ -397,8 +419,9 @@ public sealed class VisualBasicCompilationData : CompilationData<VisualBasicComp
         EmitData emitData,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
-        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
-        : base(compilerCall, compilation, parseOptions, emitOptions, emitData, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
+        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider,
+        ImmutableArray<Diagnostic> creationDiagnostics)
+        : base(compilerCall, compilation, parseOptions, emitOptions, emitData, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider, creationDiagnostics)
     {
     }
 

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -437,16 +437,15 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
 
         void HandleCryptoKeyFile(string? contentHash, string originalFilePath)
         {
-            if (contentHash is null)
-            {
-                diagnostics.Add(Diagnostic.Create(RoslynUtil.CannotReadFileDiagnosticDescriptor, Location.None, Path.GetFileName(originalFilePath)));
-                return;
-            }
-
             var dir = Path.Combine(LogReaderState.CryptoKeyFileDirectory, GetIndex(compilerCall).ToString());
             Directory.CreateDirectory(dir);
-            var filePath = Path.Combine(dir, $"{contentHash}.snk");
-            File.WriteAllBytes(filePath, GetContentBytes(contentHash));
+            var filePath = Path.Combine(dir, Path.GetFileName(originalFilePath));
+
+            if (contentHash is not null)
+            {
+                File.WriteAllBytes(filePath, GetContentBytes(contentHash));
+            }
+
             compilationOptions = compilationOptions.WithCryptoKeyFile(filePath);
         }
 

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -319,6 +319,12 @@ public sealed partial class ExportUtil
                     continue;
                 }
 
+                if (rawContent.ContentHash is null)
+                {
+                    commandLineList.Add($@"{prefix}{FormatPathArgument(builder.GetNewSourcePath(rawContent.OriginalFilePath))}");
+                    continue;
+                }
+
                 string? filePath = null;
                 if (rawContent.Kind == RawContentKind.AnalyzerConfig)
                 {
@@ -344,8 +350,16 @@ public sealed partial class ExportUtil
         {
             foreach (var rawContent in Reader.ReadAllRawContent(compilerCall, RawContentKind.GeneratedText))
             {
-                using var contentStream = Reader.GetContentStream(rawContent.ContentHash);
-                var filePath = builder.GeneratedCodeDirectory.WriteContent(rawContent.OriginalFilePath, contentStream);
+                string filePath;
+                if (rawContent.ContentHash is not null)
+                {
+                    using var contentStream = Reader.GetContentStream(rawContent.ContentHash);
+                    filePath = builder.GeneratedCodeDirectory.WriteContent(rawContent.OriginalFilePath, contentStream);
+                }
+                else
+                {
+                    filePath = builder.GetNewSourcePath(rawContent.OriginalFilePath);
+                }
 
                 if (!IncludeAnalyzers)
                 {
@@ -358,8 +372,11 @@ public sealed partial class ExportUtil
         {
             foreach (var rawContent in Reader.ReadAllRawContent(compilerCall, RawContentKind.EmbedLine))
             {
-                using var contentStream = Reader.GetContentStream(rawContent.ContentHash);
-                var newPath = builder.WriteContent(rawContent.OriginalFilePath, contentStream);
+                if (rawContent.ContentHash is not null)
+                {
+                    using var contentStream = Reader.GetContentStream(rawContent.ContentHash);
+                    _ = builder.WriteContent(rawContent.OriginalFilePath, contentStream);
+                }
             }
         }
 

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -211,15 +211,6 @@ internal sealed class InMemoryLoader
 
 file sealed class BasicAnalyzerReference : AnalyzerReference
 {
-    public static readonly DiagnosticDescriptor CannotLoadTypes =
-        new DiagnosticDescriptor(
-            "BCLA0002",
-            "Failed to load types from assembly",
-            "Failed to load types from {0}: {1}",
-            "BasicCompilerLog",
-            DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
     internal AssemblyName AssemblyName { get; }
     internal byte[] AssemblyBytes { get; }
     internal InMemoryLoader Loader { get; }
@@ -286,7 +277,7 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
         }
         catch (Exception ex)
         {
-            var diagnostic = Diagnostic.Create(CannotLoadTypes, Location.None, AssemblyName.FullName, ex.Message);
+            var diagnostic = Diagnostic.Create(RoslynUtil.CannotLoadTypesDiagnosticDescriptor, Location.None, AssemblyName.FullName, ex.Message);
             OnDiagnostic(diagnostic);
             return [];
         }

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
@@ -13,15 +13,6 @@ namespace Basic.CompilerLog.Util.Impl;
 /// </summary>
 internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
 {
-    public static readonly DiagnosticDescriptor CannotReadGeneratedFiles =
-        new DiagnosticDescriptor(
-            "BCLA0001",
-            "Cannot read generated files",
-            "Error reading generated files: {0}",
-            "BasicCompilerLog",
-            DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
-
     internal List<(SourceText SourceText, string FilePath)> GeneratedSourceTexts { get; }
     internal BasicAnalyzerHostNoneAnalyzerReference? Generator { get; }
 
@@ -43,7 +34,7 @@ internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
     internal BasicAnalyzerHostNone(string errorMessage)
         : this([])
     {
-        AddDiagnostic(Diagnostic.Create(CannotReadGeneratedFiles, Location.None, errorMessage));
+        AddDiagnostic(Diagnostic.Create(RoslynUtil.CannotReadGeneratedFilesDiagnosticDescriptor, Location.None, errorMessage));
     }
 
     /// <summary>

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostOnDisk.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostOnDisk.cs
@@ -130,15 +130,6 @@ internal sealed class OnDiskLoader : AssemblyLoadContext, IAnalyzerAssemblyLoade
 
 internal sealed class OnDiskLoader : IAnalyzerAssemblyLoader, IDisposable
 {
-    public static readonly DiagnosticDescriptor CannotFindAssembly =
-        new DiagnosticDescriptor(
-            "BCLA0003",
-            "Cannot find assembly",
-            "Cannot find assembly {0}",
-            "BasicCompilerLog",
-            DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
-
     internal string Name { get; }
     internal string AnalyzerDirectory { get; }
     internal Action<Diagnostic> OnDiagnostic { get; }
@@ -189,7 +180,7 @@ internal sealed class OnDiskLoader : IAnalyzerAssemblyLoader, IDisposable
             return Assembly.LoadFrom(name);
         }
 
-        var diagnostic = Diagnostic.Create(CannotFindAssembly, Location.None, assemblyName);
+        var diagnostic = Diagnostic.Create(RoslynUtil.CannotFindAssemblyDiagnosticDescriptor, Location.None, assemblyName);
         OnDiagnostic(diagnostic);
         return null;
     }

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -38,13 +38,13 @@ internal readonly struct RawContent
 {
     internal string OriginalFilePath { get; }
     internal string NormalizedFilePath { get; }
-    internal string ContentHash { get; }
+    internal string? ContentHash { get; }
     internal RawContentKind Kind { get; }
 
     internal RawContent(
         string originalFilePath,
         string normalizedFilePath,
-        string contentHash,
+        string? contentHash,
         RawContentKind kind)
     {
         OriginalFilePath = originalFilePath;

--- a/src/Basic.CompilerLog.Util/SdkUtil.cs
+++ b/src/Basic.CompilerLog.Util/SdkUtil.cs
@@ -16,7 +16,7 @@ public static class SdkUtil
 {
     public static string GetDotnetDirectory(string? path = null)
     {
-        // TODO: has to be a better way to find the runtime directory but this works for the moment
+        // TODO: has to be a better way to find the runtime directory but this works for the moment 
         path ??= Path.GetDirectoryName(typeof(object).Assembly.Location);
         while (path is not null && !IsDotNetDir(path))
         {

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -163,8 +163,11 @@ public class EmitOptionsPack
 [MessagePackObject]
 public class ContentPack
 {
+    /// <summary>
+    /// This will be null when the file was not able to be read at creation time
+    /// </summary>
     [Key(0)]
-    public string ContentHash { get; set; }
+    public string? ContentHash { get; set; }
     [Key(1)]
     public string FilePath { get; set; }
 }


### PR DESCRIPTION
This changes compiler logs to be more tolerant of missing disk artifacts. The old strategy was to simply error and bail out when artifacts were missing on disk. This was designed primarily to make sure customers weren't creating and submitting _stale_ binary logs.

Diagnostics around potentially _stale_ logs are valuable but it was too agressive. It meant that the tooling couldn't represent `Compilations` with those types of errors. For example: instead of creating a `Compilation` where emit fails because of a missing key file the tooling just could not create a `Compilation` at all.

This change is pushing the tooling to be tolerant of the missing artifacts while preserving the _stale_ diagnostics in `complog create`.

closes #217