### PR TITLE
Avoid running continuations from long running thread

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -616,7 +616,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                     {
                         tcs.SetException(ex);
                     }
-                }, TaskCreationOptions.LongRunning);
+                }, TaskCreationOptions.LongRunning | TaskCreationOptions.RunContinuationsAsynchronously);
 
                 logData = await tcs.Task;
             }


### PR DESCRIPTION
This wasn't a result of a problem I faced, but I spotted here there may be an issue where each time through this loop this code will be running the continuations from the long running thread that was previously created.

Creating a pseudo code example locally I can see that this will create a long chain of threads, and with `RunContinuationsAsynchronously` it will likely reuse the same thread from the thread pool.