### PR TITLE
Embedded PDB do not need streams

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -276,6 +276,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                     <TargetFramework>net8.0</TargetFramework>
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
+                    <DebugType>embedded</DebugType>
                     <EmbedAllSources>true</EmbedAllSources>
                     <CodeAnalysisRuleset>{scratchPath}\example.ruleset</CodeAnalysisRuleset>
                     <Win32Manifest>resource.txt</Win32Manifest>

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -6,6 +6,7 @@ using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
@@ -73,7 +74,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
                     Assert.NotEmpty(emitResult.AssemblyFilePath);
 
                     var emitFlags = data.EmitFlags;
-                    if ((emitFlags & EmitFlags.IncludePdbStream) != 0)
+                    if ((emitFlags & EmitFlags.IncludePdbStream) != 0 && data.EmitOptions.DebugInformationFormat != DebugInformationFormat.Embedded)
                     {
                         Assert.NotNull(emitResult.PdbFilePath);
                     }

--- a/src/Basic.CompilerLog.Util/CodeAnalysisExtensions.cs
+++ b/src/Basic.CompilerLog.Util/CodeAnalysisExtensions.cs
@@ -39,7 +39,7 @@ public static class CodeAnalysisExtensions
         MemoryStream? xmlStream = null;
         MemoryStream? metadataStream = null;
 
-        if ((emitFlags & EmitFlags.IncludePdbStream) != 0)
+        if ((emitFlags & EmitFlags.IncludePdbStream) != 0 && emitOptions.DebugInformationFormat != DebugInformationFormat.Embedded)
         {
             pdbStream = new MemoryStream();
         }

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -274,7 +274,7 @@ public abstract class CompilationData
         { 
             peStream = OpenFile(assemblyFilePath);
 
-            if ((emitFlags & EmitFlags.IncludePdbStream) != 0)
+            if ((emitFlags & EmitFlags.IncludePdbStream) != 0 && emitOptions.DebugInformationFormat != DebugInformationFormat.Embedded)
             {
                 pdbFilePath = Path.Combine(directory, Path.ChangeExtension(assemblyName, ".pdb"));
                 pdbStream = OpenFile(pdbFilePath);

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -40,6 +40,7 @@ catch (Exception e)
 {
     WriteLine("Unexpected error");
     WriteLine(e.Message);
+    WriteLine(e.StackTrace!);
     RunHelp(null);
     return ExitFailure;
 }

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -5,6 +5,7 @@ using System.IO.Pipelines;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text;
 using System.Threading.Tasks;
 using Basic.CompilerLog;
 using Basic.CompilerLog.Util;
@@ -25,10 +26,8 @@ using TraceReloggerLib;
 
 #pragma warning disable 8321
 
-var zipFilePath = @"C:\Users\jaredpar\Downloads\msbuild_logs.zip";
 //using var reader = CompilerLogReader.Create(zipFilePath);
-RunComplog($"print -c {zipFilePath}");
-
+RunComplog(@$"replay C:\Users\jaredpar\Downloads\msbuild.complog");
 
 
 /*


### PR DESCRIPTION
When building with embedded PDBs the `Emit*` methods were incorrectly passing a `Stream` for the PDB. That is not needed as the PDB is written into the PE file directly