### PR TITLE
Fix exporting complex paths

### DIFF
--- a/src/Basic.CompilerLog.Util/MiscDirectory.cs
+++ b/src/Basic.CompilerLog.Util/MiscDirectory.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Basic.CompilerLog.Util;
+
+/// <summary>
+/// Abstraction for getting new file paths for original paths in the compilation that existed
+/// outside the cone of the project. For paths like that it's important to keep the original
+/// directory structure. There are many parts of compilation that are hierarchical like 
+/// editorconfig that require this.
+/// </summary>
+internal sealed class MiscDirectory(string baseDirectory)
+{
+    private string BaseDirectory { get; } = baseDirectory;
+    private Dictionary<string, string> Map { get; } = new(PathUtil.Comparer);
+
+    public string GetNewFilePath(string path)
+    {
+        if (Map.TryGetValue(path, out var newPath))
+        {
+            return newPath;
+        }
+
+        var parent = Path.GetDirectoryName(path);
+        if (parent is null)
+        {
+            return BaseDirectory;
+        }
+
+        var newParent = GetNewFilePath(parent);
+        _ = Directory.CreateDirectory(newParent);
+        newPath = Path.Combine(newParent, Path.GetFileName(path));
+        Map.Add(path, newPath);
+        return newPath;
+    }
+}

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Composition;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Reflection;
@@ -27,8 +28,18 @@ using TraceReloggerLib;
 #pragma warning disable 8321
 
 //using var reader = CompilerLogReader.Create(zipFilePath);
-RunComplog(@$"replay C:\Users\jaredpar\Downloads\msbuild.complog");
+var filePath = @"C:\Users\jaredpar\Downloads\msbuild.complog";
+using var reader = CompilerLogReader.Create(filePath);
+var exportUtil = new ExportUtil(reader);
 
+var dir = @"C:\Users\jaredpar\temp\export";
+if (Directory.Exists(dir))
+{
+    Directory.EnumerateDirectories(dir).ToList().ForEach(x => Directory.Delete(x, recursive: true));
+}
+
+Directory.CreateDirectory(dir);
+exportUtil.ExportAll(dir, SdkUtil.GetSdkDirectories());
 
 /*
 using var reader = CompilerCallReaderUtil.Create("/home/jaredpar/code/msbuild/artifacts/log/Debug/Build.binlog", BasicAnalyzerKind.None);


### PR DESCRIPTION
The source root during export needs to consider editorconfig files that may exist _above_ the project file.