### PR TITLE
Option to include analyzer / generator type names 

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -158,11 +158,20 @@ public sealed class ProgramTests : TestBase
     }
 
     [Fact]
-    public void AnalyzerBadOption()
+    public void AnalyzersBadOption()
     {
         var (exitCode, output) = RunCompLogEx($"analyzers {Fixture.RemovedBinaryLogPath} --not-an-option");
         Assert.NotEqual(Constants.ExitSuccess, exitCode);
         Assert.StartsWith("Extra arguments", output); 
+    }
+
+    [Fact]
+    public void AnalyzersSimple()
+    {
+        var (exitCode, output) = RunCompLogEx($"analyzers {Fixture.SolutionBinaryLogPath}");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Contains("Analyzers:", output); 
+        Assert.Contains("Generators:", output); 
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -170,6 +170,11 @@ public sealed class ProgramTests : TestBase
     {
         var (exitCode, output) = RunCompLogEx($"analyzers {Fixture.SolutionBinaryLogPath}");
         Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.DoesNotContain("Analyzers:", output); 
+        Assert.DoesNotContain("Generators:", output); 
+
+        (exitCode, output) = RunCompLogEx($"analyzers {Fixture.SolutionBinaryLogPath} -t");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
         Assert.Contains("Analyzers:", output); 
         Assert.Contains("Generators:", output); 
     }

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -1,6 +1,9 @@
 using System.Drawing.Drawing2D;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using Basic.CompilerLog.Util;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
@@ -244,6 +247,28 @@ public sealed class RoslynUtilTests
             additionalReferenceDirectories: null);
         var actualFileName = RoslynUtil.GetAssemblyFileName(args);
         Assert.Equal(expectedFileName, actualFileName);
+    }
+
+    [Fact]
+    public void GetAnalyzerTypeDefinitions()
+    {
+        var (_, image) = LibraryUtil.GetAnalyzersWithDiffAttribtueCombinations();
+        using var peReader = new PEReader(image);
+        var metadataReader = peReader.GetMetadataReader();
+
+        var list = RoslynUtil.GetAnalyzerTypeDefinitions(metadataReader, LanguageNames.CSharp).ToList();
+        Assert.Single(list);
+        list = RoslynUtil.GetAnalyzerTypeDefinitions(metadataReader, LanguageNames.VisualBasic).ToList();
+        Assert.Single(list);
+        list = RoslynUtil.GetAnalyzerTypeDefinitions(metadataReader, languageName: null).ToList();
+        Assert.Equal(2, list.Count);
+
+        list = RoslynUtil.GetGeneratorTypeDefinitions(metadataReader, LanguageNames.CSharp).ToList();
+        Assert.Equal(2, list.Count);
+        list = RoslynUtil.GetGeneratorTypeDefinitions(metadataReader, null).ToList();
+        Assert.Equal(3, list.Count);
+        list = RoslynUtil.GetAnalyzerTypeDefinitions(metadataReader, LanguageNames.VisualBasic).ToList();
+        Assert.Single(list);
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -483,11 +483,11 @@ public sealed partial class ExportUtil
     /// </summary>
     internal static string GetSourceDirectory(CompilerLogReader reader, CompilerCall compilerCall)
     {
-        var sourceRootDir = Path.GetDirectoryName(compilerCall.ProjectFilePath);
+        var sourceRootDir = Path.GetDirectoryName(compilerCall.ProjectFilePath)!;
 
         foreach (var content in reader.ReadAllRawContent(compilerCall, RawContentKind.AnalyzerConfig))
         {
-            var contentDir = Path.GetDirectoryName(content.OriginalFilePath);
+            var contentDir = Path.GetDirectoryName(content.OriginalFilePath)!;
             if (!sourceRootDir.StartsWith(contentDir, PathUtil.Comparison))
             {
                 continue;

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -793,7 +793,7 @@ internal static class RoslynUtil
             foreach (var handle in typeDef.GetCustomAttributes())
             {
                 var attribute = metadataReader.GetCustomAttribute(handle);
-                if (IsMatchingAttribute(attribute))
+                if (IsMatchingAttribute(attribute) && predicate(typeDef, attribute))
                 {
                     yield return (typeDef, attribute);
                 }

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -1,10 +1,10 @@
 ﻿using Basic.CompilerLog;
 using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Mono.Options;
 using StructuredLogViewer;
 using System.Diagnostics;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Text;
@@ -141,6 +141,19 @@ int RunAnalyzers(IEnumerable<string> args)
             foreach (var data in reader.ReadAllAnalyzerData(compilerCall))
             {
                 WriteLine($"\t{data.FilePath}");
+
+                var (analyzers, generators) = reader.ReadAnalyzerFullTypeNames(data, compilerCall.IsCSharp);
+                WriteLine($"\tAnalyzers:");
+                foreach (var analyzer in analyzers)
+                {
+                    WriteLine($"\t\t{analyzer}");
+                } 
+
+                WriteLine($"\tGenerators:");
+                foreach (var generator in generators)
+                {
+                    WriteLine($"\t\t{generator}");
+                } 
             }
         }
 

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -122,7 +122,11 @@ int RunCreate(IEnumerable<string> args)
 
 int RunAnalyzers(IEnumerable<string> args)
 {
-    var options = new FilterOptionSet();
+    var includeTypes = false;
+    var options = new FilterOptionSet()
+    {
+        { "t|types", "include type names", o => includeTypes = o is not null },
+    };
 
     try
     {
@@ -142,18 +146,21 @@ int RunAnalyzers(IEnumerable<string> args)
             {
                 WriteLine($"\t{data.FilePath}");
 
-                var (analyzers, generators) = reader.ReadAnalyzerFullTypeNames(data, compilerCall.IsCSharp);
-                WriteLine($"\tAnalyzers:");
-                foreach (var analyzer in analyzers)
+                if (includeTypes)
                 {
-                    WriteLine($"\t\t{analyzer}");
-                } 
+                    var (analyzers, generators) = reader.ReadAnalyzerFullTypeNames(data, compilerCall.IsCSharp);
+                    WriteLine($"\tAnalyzers:");
+                    foreach (var analyzer in analyzers)
+                    {
+                        WriteLine($"\t\t{analyzer}");
+                    } 
 
-                WriteLine($"\tGenerators:");
-                foreach (var generator in generators)
-                {
-                    WriteLine($"\t\t{generator}");
-                } 
+                    WriteLine($"\tGenerators:");
+                    foreach (var generator in generators)
+                    {
+                        WriteLine($"\t\t{generator}");
+                    } 
+                }
             }
         }
 


### PR DESCRIPTION
Adds the option to include analyzer / generator type names in the `complog analyzers` output. 