### PR TITLE
Ability to capture compilation ids

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,5 +2,5 @@ FROM mcr.microsoft.com/devcontainers/dotnet:8.0
 
 RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && \
     chmod +x dotnet-install.sh && \
-    ./dotnet-install.sh --channel 9.0 --version latest --quality preview --install-dir /usr/share/dotnet && \
+    ./dotnet-install.sh --channel 9.0 --version latest --install-dir /usr/share/dotnet && \
     rm dotnet-install.sh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,7 @@ jobs:
             test-results: test-results-linux
 
     env:
-      TEST_ARTIFACTS_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test
+      TEST_ARTIFACTS_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test-artifacts
       TEST_RESULTS_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}test-results
       TEST_COVERAGE_PATH: ${{ github.workspace }}${{ matrix.slash }}artifacts${{ matrix.slash }}coverage
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -114,9 +114,12 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
         Directory.CreateDirectory(ComplogDirectory);
         Directory.CreateDirectory(ScratchDirectory);
 
-        string? testArtifactsDir = TestUtil.InGitHubActions
-            ? TestUtil.GitHubActionsTestArtifactsDirectory
-            : null;
+        string? testArtifactsDir = null;
+        if (TestUtil.InGitHubActions)
+        {
+            testArtifactsDir = Path.Combine(TestUtil.GitHubActionsTestArtifactsDirectory, "compilerlogfixture");
+            Directory.CreateDirectory(testArtifactsDir);
+        }
 
         var builder = ImmutableArray.CreateBuilder<Lazy<LogData>>();
         Console = WithBuild("console.complog", void (string scratchPath) =>

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -114,12 +114,9 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
         Directory.CreateDirectory(ComplogDirectory);
         Directory.CreateDirectory(ScratchDirectory);
 
-        var testArtifactsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS_PATH");
-        if (testArtifactsDir is not null)
-        {
-            testArtifactsDir = Path.Combine(testArtifactsDir, Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(testArtifactsDir);
-        }
+        string? testArtifactsDir = TestUtil.InGitHubActions
+            ? TestUtil.GitHubActionsTestArtifactsDirectory
+            : null;
 
         var builder = ImmutableArray.CreateBuilder<Lazy<LogData>>();
         Console = WithBuild("console.complog", void (string scratchPath) =>

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -353,6 +353,16 @@ public sealed class ProgramTests : TestBase
     }
 
     [Fact]
+    public void IdPrint()
+    {
+        var dir = Root.NewDirectory();
+        RunDotNet($"new console --name example --output .", dir);
+        var (exitCode, output) = RunCompLogEx($"id --print", dir);
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Contains("example.csproj", output);
+    }
+
+    [Fact]
     public void IdInlineAndOutput()
     {
         var dir = Root.NewDirectory();

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -333,9 +333,13 @@ public sealed class ProgramTests : TestBase
         Assert.Equal(Constants.ExitSuccess, exitCode);
         Assert.Contains("Generating id files inline", output);
 
+        var contentFilePath = Path.Combine(dir, "build-id.content.txt");
+        TestOutputHelper.WriteLine(File.ReadAllText(contentFilePath));
+
         var idFilePath = Path.Combine(dir, "build-id.txt");
         Assert.True(File.Exists(idFilePath));
         var id = File.ReadAllText(idFilePath);
+
         var expectedId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
             ? ""
             : "44623228E885285F845DBF3731EEE4155C6972B05E51A2494485A4581FC14960";

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -342,7 +342,7 @@ public sealed class ProgramTests : TestBase
 
             var expectedId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
                 ? ""
-                : "D339B2B333F7C2344D6AFD47135FF7BF6F7DF64FB9E5E5E76690B093FC302BF9"
+                : "D339B2B333F7C2344D6AFD47135FF7BF6F7DF64FB9E5E5E76690B093FC302BF9";
             Assert.Equal(expectedId, id);
         }
         catch (Exception)

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -102,7 +102,10 @@ public sealed class ProgramTests : TestBase
             {
                 Assert.Empty(Directory.EnumerateFileSystemEntries(Constants.LocalAppDataDirectory));
             }
-            return ((int)ret!, writer.ToString());
+
+            var output = writer.ToString();
+            TestOutputHelper.WriteLine(output);
+            return ((int)ret!, output);
         }
         finally
         {
@@ -308,7 +311,6 @@ public sealed class ProgramTests : TestBase
     public void Id()
     {
         var (exitCode, output) = RunCompLogEx($"id {Fixture.SolutionBinaryLogPath}");
-        TestOutputHelper.WriteLine(output);
         Assert.Equal(Constants.ExitSuccess, exitCode);
         var dir = Path.Combine(RootDirectory, ".complog");
         var files = Directory.EnumerateFiles(dir, "build-id.txt", SearchOption.AllDirectories);

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -308,7 +308,8 @@ public sealed class ProgramTests : TestBase
     public void Id()
     {
         var (exitCode, output) = RunCompLogEx($"id {Fixture.SolutionBinaryLogPath}");
-        Assert.Equal(Constants.ExitSuccess, exitCode, output);
+        TestOutputHelper.WriteLine(output);
+        Assert.Equal(Constants.ExitSuccess, exitCode);
         var dir = Path.Combine(RootDirectory, ".complog");
         var files = Directory.EnumerateFiles(dir, "build-id.txt", SearchOption.AllDirectories);
         Assert.NotEmpty(files);

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -334,16 +334,22 @@ public sealed class ProgramTests : TestBase
         Assert.Contains("Generating id files inline", output);
 
         var contentFilePath = Path.Combine(dir, "build-id.content.txt");
-        TestOutputHelper.WriteLine(File.ReadAllText(contentFilePath));
+        try
+        {
+            var idFilePath = Path.Combine(dir, "build-id.txt");
+            Assert.True(File.Exists(idFilePath));
+            var id = File.ReadAllText(idFilePath);
 
-        var idFilePath = Path.Combine(dir, "build-id.txt");
-        Assert.True(File.Exists(idFilePath));
-        var id = File.ReadAllText(idFilePath);
-
-        var expectedId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
-            ? ""
-            : "44623228E885285F845DBF3731EEE4155C6972B05E51A2494485A4581FC14960";
-        Assert.Equal(expectedId, id);
+            var expectedId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+                ? ""
+                : "44623228E885285F845DBF3731EEE4155C6972B05E51A2494485A4581FC14960";
+            Assert.Equal(expectedId, id);
+        }
+        catch (Exception)
+        {
+            AddFileToTestArtifacts(contentFilePath);
+            throw;
+        }
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -118,12 +118,12 @@ public sealed class ProgramTests : TestBase
 
     private static string GetIdentityHashConsole() =>
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "wrong"
+            ? "0E662CF750EE1DD812AB28EEF043007BFE72655681838EB7AA35EC9BD48541FC"
             : "3100BA355001A464D45D7636823F4B7E1729368DAFBA20BC1C482B9F6FA9E5E4";
 
     private static string GetIdentityHashExample() =>
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "wrong"
+            ? "7EEAE6122F14D721453ED7DEAE7E1BE1D7AC3E0D69657834FF376D91888A7B11"
             : "D339B2B333F7C2344D6AFD47135FF7BF6F7DF64FB9E5E5E76690B093FC302BF9";
 
     private void RunWithBoth(Action<string> action)

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -308,7 +308,7 @@ public sealed class ProgramTests : TestBase
     public void Id()
     {
         var (exitCode, output) = RunCompLogEx($"id {Fixture.SolutionBinaryLogPath}");
-        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Equal(Constants.ExitSuccess, exitCode, output);
         var dir = Path.Combine(RootDirectory, ".complog");
         var files = Directory.EnumerateFiles(dir, "build-id.txt", SearchOption.AllDirectories);
         Assert.NotEmpty(files);

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -342,7 +342,7 @@ public sealed class ProgramTests : TestBase
 
             var expectedId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
                 ? ""
-                : "44623228E885285F845DBF3731EEE4155C6972B05E51A2494485A4581FC14960";
+                : "D339B2B333F7C2344D6AFD47135FF7BF6F7DF64FB9E5E5E76690B093FC302BF9"
             Assert.Equal(expectedId, id);
         }
         catch (Exception)

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -305,6 +305,18 @@ public sealed class ProgramTests : TestBase
     }
 
     [Fact]
+    public void Id()
+    {
+        var (exitCode, output) = RunCompLogEx($"id {Fixture.SolutionBinaryLogPath}");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        var dir = Path.Combine(RootDirectory, ".complog");
+        var files = Directory.EnumerateFiles(dir, "build-id.txt", SearchOption.AllDirectories);
+        Assert.NotEmpty(files);
+        files = Directory.EnumerateFiles(dir, "build-id.content.txt", SearchOption.AllDirectories);
+        Assert.NotEmpty(files);
+    }
+
+    [Fact]
     public void References()
     {
         RunWithBoth(logPath =>

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -317,6 +317,47 @@ public sealed class ProgramTests : TestBase
     }
 
     [Fact]
+    public void IdHelp()
+    {
+        var (exitCode, output) = RunCompLogEx($"id -h");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.StartsWith("complog id [OPTIONS]", output);
+    }
+
+    [Fact]
+    public void IdInline()
+    {
+        var dir = Root.NewDirectory();
+        RunDotNet($"new console --name example --output .", dir);
+        var (exitCode, output) = RunCompLogEx($"id -i", dir);
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Contains("Generating id files inline", output);
+
+        var idFilePath = Path.Combine(dir, "build-id.txt");
+        Assert.True(File.Exists(idFilePath));
+        var id = File.ReadAllText(idFilePath);
+        var expectedId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+            ? ""
+            : "44623228E885285F845DBF3731EEE4155C6972B05E51A2494485A4581FC14960";
+        Assert.Equal(expectedId, id);
+    }
+
+    [Fact]
+    public void IdInlineAndOutput()
+    {
+        var dir = Root.NewDirectory();
+        var (exitCode, output) = RunCompLogEx($"id -i -o blah");
+        Assert.NotEqual(Constants.ExitSuccess, exitCode);
+    }
+
+    [Fact]
+    public void IdBadOption()
+    {
+        var (exitCode, output) = RunCompLogEx($"id -blah");
+        Assert.NotEqual(Constants.ExitSuccess, exitCode);
+    }
+
+    [Fact]
     public void References()
     {
         RunWithBoth(logPath =>

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -326,6 +326,14 @@ public sealed class ProgramTests : TestBase
     }
 
     [Fact]
+    public void HashNoCommand()
+    {
+        var (exitCode, output) = RunCompLogEx("hash");
+        Assert.NotEqual(Constants.ExitSuccess, exitCode);
+        Assert.Contains("Need a subcommand", output);
+    }
+
+    [Fact]
     public void HashHelp()
     {
         var (exitCode, output) = RunCompLogEx("hash help");
@@ -354,9 +362,17 @@ public sealed class ProgramTests : TestBase
     [Fact]
     public void HashPrintHelp()
     {
-        var (exitCode, output) = RunCompLogEx($"hash print -h");
+        var (exitCode, output) = RunCompLogEx("hash print -h");
         Assert.Equal(Constants.ExitSuccess, exitCode);
         Assert.StartsWith("complog hash print [OPTIONS]", output);
+    }
+
+    [Fact]
+    public void HashPrintBadOption()
+    {
+        var (exitCode, output) = RunCompLogEx("hash print --does-not-exist");
+        Assert.NotEqual(Constants.ExitSuccess, exitCode);
+        Assert.Contains("complog hash print [OPTIONS]", output);
     }
 
     [Fact]
@@ -404,6 +420,30 @@ public sealed class ProgramTests : TestBase
                     "outputKind": "ConsoleApplication",
                     "moduleName": "example.dll",
               """, File.ReadAllText(contentFilePath));
+    }
+
+    [Fact]
+    public void HashExportBadOption()
+    {
+        var (exitCode, output) = RunCompLogEx("hash export --does-not-exist");
+        Assert.NotEqual(Constants.ExitSuccess, exitCode);
+        Assert.Contains("complog hash export [OPTIONS]", output);
+    }
+
+    [Fact]
+    public void HashExportInlineAndOutput()
+    {
+        var (exitCode, output) = RunCompLogEx("hash export --inline --out example");
+        Assert.NotEqual(Constants.ExitSuccess, exitCode);
+        Assert.Contains("complog hash export [OPTIONS]", output);
+    }
+
+    [Fact]
+    public void HashExportHelp()
+    {
+        var (exitCode, output) = RunCompLogEx("hash export -h");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Contains("complog hash export [OPTIONS]", output);
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -120,7 +120,6 @@ public abstract class TestBase : IDisposable
             }
             Assert.Fail("Bad assembly loads");
         }
-        TestOutputHelper.WriteLine("Deleting temp directory");
         Root.Dispose();
     }
 

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -301,14 +301,10 @@ public abstract class TestBase : IDisposable
 
         string testResultsDir;
         bool overwrite;
-        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null)
+        if (TestUtil.InGitHubActions)
         {
             overwrite = false;
-            testResultsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS_PATH")!;
-            if (testResultsDir is null)
-            {
-                throw new InvalidOperationException("TEST_ARTIFACTS_PATH is not set in GitHub Actions");
-            }
+            testResultsDir = TestUtil.GitHubActionsTestArtifactsDirectory;
         }
         else
         {

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -1,4 +1,5 @@
 
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -10,6 +11,25 @@ namespace Basic.CompilerLog.UnitTests;
 
 internal static class TestUtil
 {
+    internal static bool InGitHubActions => Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null;
+
+    internal static string GitHubActionsTestArtifactsDirectory
+    {
+        get
+        {
+            Debug.Assert(InGitHubActions);
+
+            var testArtifactsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS_PATH");
+            if (testArtifactsDir is null)
+            {
+                throw new Exception("TEST_ARTIFACTS_PATH is not set in GitHub actions");
+
+            }
+
+            return testArtifactsDir;
+        }
+    }
+
     /// <summary>
     /// Internally a <see cref="IIncrementalGenerator" /> is wrapped in a type called IncrementalGeneratorWrapper. 
     /// This method will dig through that and return the original type.

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -11,6 +11,15 @@ namespace Basic.CompilerLog.UnitTests;
 
 internal static class TestUtil
 {
+    internal static bool IsNetFramework => 
+#if NETFRAMEWORK
+        true;
+#else
+        false;
+#endif
+
+    internal static bool IsNetCore => !IsNetFramework;
+
     internal static bool InGitHubActions => Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null;
 
     internal static string GitHubActionsTestArtifactsDirectory
@@ -26,7 +35,9 @@ internal static class TestUtil
 
             }
 
-            return testArtifactsDir;
+            var suffix = IsNetCore ? "netcore" : "netfx";
+
+            return Path.Combine(testArtifactsDir, suffix);
         }
     }
 

--- a/src/Basic.CompilerLog.UnitTests/xunit.runner.json
+++ b/src/Basic.CompilerLog.UnitTests/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "appDomain": "ifAvailable",
   "shadowCopy": false,
-  "parallelizeTestCollections": false
+  "parallelizeTestCollections": false,
+  "printMaxStringLength": 0
 }

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -369,7 +369,7 @@ public abstract class CompilationData
     public string GetCompilationContentText()
     {
         var assembly = typeof(Compilation).Assembly;
-        var type = assembly.GetType( "Microsoft.CodeAnalysis.DeterministicKey", throwOnError: true);
+        var type = assembly.GetType( "Microsoft.CodeAnalysis.DeterministicKey", throwOnError: true)!;
         var method = type
             .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
             .Where(x => IsMethod(x))

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -375,10 +375,16 @@ public abstract class CompilationData
             .Where(x => IsMethod(x))
             .Single();
 
+        // This removes our implementation of the syntax tree options provider. Leaving that in means
+        // that the content text will be different every time compiler log is updated and that is not
+        // desirable.
+        var options = CompilationOptions.WithSyntaxTreeOptionsProvider(null);
+
+        // This removes file full paths and tool versions from the content text.
         int flags = 0b11;
         object[] args = 
         [
-            CompilationOptions,
+            options,
             Compilation.SyntaxTrees.ToImmutableArray(),
             Compilation.References.ToImmutableArray(),
             ImmutableArray<byte>.Empty,

--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -426,7 +426,7 @@ internal sealed class CompilerLogBuilder : IDisposable
         Debug.Assert(stream.Position == 0);
         var sha = SHA256.Create();
         var hash = sha.ComputeHash(stream);
-        var hashText = GetHashText();
+        var hashText = hash.AsHexString();
 
         if (_contentHashMap.Add(hashText))
         {
@@ -437,17 +437,6 @@ internal sealed class CompilerLogBuilder : IDisposable
         }
 
         return hashText;
-
-        string GetHashText()
-        {
-            var builder = new StringBuilder();
-            foreach (var b in hash)
-            {
-                builder.Append($"{b:X2}");
-            }
-
-            return builder.ToString();
-        }
     }
 
     private void AddReferences(CompilationDataPack dataPack, CommandLineArguments args)

--- a/src/Basic.CompilerLog.Util/Extensions.cs
+++ b/src/Basic.CompilerLog.Util/Extensions.cs
@@ -120,4 +120,17 @@ public static class Extensions
 
         return (analyzers, generators);
     }
+
+    public static string AsHexString(this byte[] bytes) => AsHexString(bytes.AsSpan());
+
+    public static string AsHexString(this ReadOnlySpan<byte> bytes)
+    {
+        var builder = new StringBuilder();
+        foreach (var b in bytes)
+        {
+            builder.Append($"{b:X2}");
+        }
+
+        return builder.ToString();
+    }
 }

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -750,6 +750,7 @@ int RunHashExport(IEnumerable<string> args)
         if (inline && !string.IsNullOrEmpty(baseOutputPath))
         {
             WriteLine("Cannot specify both --inline and --out");
+            PrintUsage();
             return ExitFailure;
         }
 

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -657,6 +657,7 @@ int RunId(IEnumerable<string> args)
             (true, false, false) => true,
             (false, true, false) => true,
             (false, false, true) => true,
+            (false, false, false) => true,
             _ => false
         };
 
@@ -671,7 +672,7 @@ int RunId(IEnumerable<string> args)
         {
             WriteLine($"Generating id files inline");
         }
-        else
+        else if (!print)
         {
             baseOutputPath = GetBaseOutputPath(baseOutputPath, "id");
             WriteLine($"Generating id files in {baseOutputPath}");

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -663,7 +663,7 @@ int RunId(IEnumerable<string> args)
         }
         else
         {
-            baseOutputPath = GetBaseOutputPath(baseOutputPath, "rsp");
+            baseOutputPath = GetBaseOutputPath(baseOutputPath, "id");
             WriteLine($"Generating id files in {baseOutputPath}");
             Directory.CreateDirectory(baseOutputPath);
         }
@@ -677,7 +677,7 @@ int RunId(IEnumerable<string> args)
             var compilationData = reader.ReadCompilationData(compilerCall);
             var content = compilationData.GetCompilationContentText();
             var id = sum.ComputeHash(Encoding.UTF8.GetBytes(content));
-            var idText = GetText(id);
+            var idText = id.AsHexString();
 
             var idDirPath = inline
                 ? compilerCall.ProjectDirectory
@@ -700,17 +700,6 @@ int RunId(IEnumerable<string> args)
 
                 return "build-id.txt";
             }
-
-            string GetText(byte[] hash)
-            {
-                var builder = new StringBuilder();
-                foreach (var b in hash)
-                {
-                    builder.Append($"{b:X2}");
-                }
-
-                return builder.ToString();
-            }
         }
 
         return ExitSuccess;
@@ -724,7 +713,7 @@ int RunId(IEnumerable<string> args)
 
     void PrintUsage()
     {
-        WriteLine("complog rsp [OPTIONS] msbuild.complog");
+        WriteLine("complog id [OPTIONS] msbuild.complog");
         options.WriteOptionDescriptions(Out);
     }
 }

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -28,7 +28,9 @@ using TraceReloggerLib;
 #pragma warning disable 8321
 
 //using var reader = CompilerLogReader.Create(zipFilePath);
-var filePath = @"C:\Users\jaredpar\Downloads\msbuild.complog";
+var filePath = @"C:\Users\jaredpar\temp\console\msbuild.binlog";
+RunComplog($"id --inline {filePath}");
+/*
 using var reader = CompilerLogReader.Create(filePath);
 var exportUtil = new ExportUtil(reader);
 
@@ -41,6 +43,7 @@ if (Directory.Exists(dir))
 Directory.CreateDirectory(dir);
 exportUtil.ExportAll(dir, SdkUtil.GetSdkDirectories());
 
+*/
 /*
 using var reader = CompilerCallReaderUtil.Create("/home/jaredpar/code/msbuild/artifacts/log/Debug/Build.binlog", BasicAnalyzerKind.None);
 var compilerCall = reader


### PR DESCRIPTION
This adds a command to print compilation ids: both the raw content id and the checksum version, for each compilation. These IDs represent the compilation in text form. Two equal compilations will have the same ID.