### PR TITLE
Remove silent failure of hash

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -220,4 +220,20 @@ public sealed class CompilationDataTests : TestBase
         Assert.Single(trees);
         Assert.Empty(diagnostics);
     }
+
+#if NET
+    [Fact]
+    public void GetContentHashBadAnalyzer()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ClassLib.Value.CompilerLogPath, BasicAnalyzerKind.None);
+        var data = LibraryUtil.GetAnalyzersWithBadMetadata();
+        using var host = new BasicAnalyzerHostInMemory(data.FileName, data.Image.ToArray());
+        var compilationData = reader
+            .ReadCompilationData(0)
+            .WithBasicAnalyzerHost(host);
+        var content = compilationData.GetContentHash();
+        Assert.Contains(RoslynUtil.CannotLoadTypesDiagnosticDescriptor.Id, content);
+    }
+
+#endif
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -83,7 +83,7 @@ public sealed class CompilationDataTests : TestBase
         var result = data.EmitToMemory();
         Assert.False(result.Success);
         Assert.NotEmpty(result.Diagnostics);
-        Assert.True(result.Diagnostics.Any(x => x.Id == "BCLA0001"));
+        Assert.True(result.Diagnostics.Any(x => x.Id == RoslynUtil.ErrorReadingGeneratedFilesDiagnosticDescriptor.Id));
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public sealed class CompilationDataTests : TestBase
         var result = data.EmitToDisk(Root.DirectoryPath);
         Assert.False(result.Success);
         Assert.NotEmpty(result.Diagnostics);
-        Assert.True(result.Diagnostics.Any(x => x.Id == "BCLA0001"));
+        Assert.True(result.Diagnostics.Any(x => x.Id == RoslynUtil.ErrorReadingGeneratedFilesDiagnosticDescriptor.Id));
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -222,12 +222,16 @@ public sealed class CompilationDataTests : TestBase
     }
 
 #if NET
-    [Fact]
-    public void GetContentHashBadAnalyzer()
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GetContentHashBadAnalyzer(bool inMemory)
     {
         using var reader = CompilerLogReader.Create(Fixture.ClassLib.Value.CompilerLogPath, BasicAnalyzerKind.None);
-        var data = LibraryUtil.GetAnalyzersWithBadMetadata();
-        using var host = new BasicAnalyzerHostInMemory(data.FileName, data.Image.ToArray());
+        using BasicAnalyzerHost host = inMemory
+            ? new BasicAnalyzerHostInMemory(LibraryUtil.GetUnloadableAnalyzers())
+            : new BasicAnalyzerHostOnDisk(State, LibraryUtil.GetUnloadableAnalyzers());
         var compilationData = reader
             .ReadCompilationData(0)
             .WithBasicAnalyzerHost(host);

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -280,11 +280,12 @@ public sealed class CompilerLogReaderTests : TestBase
             .Where(x => x.FileName != "Microsoft.CodeAnalysis.NetAnalyzers.dll")
             .ToList();
         var host = new BasicAnalyzerHostInMemory(reader, analyzers);
+        var list = new List<Diagnostic>();
         foreach (var analyzer in host.AnalyzerReferences)
         {
-            analyzer.GetAnalyzersForAllLanguages();
+            analyzer.AsBasicAnalyzerReference().GetAnalyzers(LanguageNames.CSharp, list);
         }
-        Assert.NotEmpty(host.GetDiagnostics());
+        Assert.NotEmpty(list);
     }
 
 #endif

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -393,7 +393,7 @@ public sealed class CompilerLogReaderTests : TestBase
         var data = reader.ReadCompilationData(0);
         var compilation = data.GetCompilationAfterGenerators(out var diagnostics, CancellationToken);
         Assert.Single(diagnostics);
-        Assert.Equal(RoslynUtil.CannotReadGeneratedFilesDiagnosticDescriptor.Id, diagnostics[0].Id);
+        Assert.Equal(RoslynUtil.ErrorReadingGeneratedFilesDiagnosticDescriptor.Id, diagnostics[0].Id);
     }
 
     [Theory]

--- a/src/Basic.CompilerLog.UnitTests/Extensions.cs
+++ b/src/Basic.CompilerLog.UnitTests/Extensions.cs
@@ -1,7 +1,9 @@
 ﻿using Basic.CompilerLog.Util;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -68,4 +70,32 @@ internal static class Extensions
             new Lazy<IReadOnlyCollection<string>>(() => args),
             ownerState);
     }
+
+    internal static CompilationData WithBasicAnalyzerHost(this CompilationData compilationData, BasicAnalyzerHost basicAnalyzerHost) =>
+        compilationData switch
+        {
+            CSharpCompilationData cs =>
+                new CSharpCompilationData(
+                    cs.CompilerCall,
+                    cs.Compilation,
+                    cs.ParseOptions,
+                    cs.EmitOptions,
+                    cs.EmitData,
+                    cs.AdditionalTexts,
+                    basicAnalyzerHost,
+                    cs.AnalyzerConfigOptionsProvider,
+                    cs.CreationDiagnostics),
+            VisualBasicCompilationData vb =>
+                new VisualBasicCompilationData(
+                    vb.CompilerCall,
+                    vb.Compilation,
+                    vb.ParseOptions,
+                    vb.EmitOptions,
+                    vb.EmitData,
+                    vb.AdditionalTexts,
+                    basicAnalyzerHost,
+                    vb.AnalyzerConfigOptionsProvider,
+                    vb.CreationDiagnostics),
+            _ => throw new NotSupportedException($"Unsupported compilation data type: {compilationData.GetType()}")
+        };
 }

--- a/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
@@ -66,8 +66,7 @@ public sealed class InMemoryLoaderTests : TestBase
             "test loader",
             alc,
             Path.GetFileNameWithoutExtension(fileName),
-            image.ToArray(),
-            d => { Assert.Fail(d.GetMessage()); });
+            image.ToArray());
         var analyzerReference = loader.AnalyzerReferences.Single();
         var analyzer = analyzerReference.GetAnalyzersForAllLanguages().Single();
         Assert.Equal("GoodAnalyzer", analyzer.GetType().Name);

--- a/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
@@ -60,8 +60,7 @@ public sealed class InMemoryLoaderTests : TestBase
     [Fact]
     public void AnalyzersBadDefinition()
     {
-        var data = LibraryUtil.GetAnalyzersWithBadMetadata();
-        using var host = new BasicAnalyzerHostInMemory(data.FileName, data.Image.ToArray());
+        using var host = new BasicAnalyzerHostInMemory(LibraryUtil.GetAnalyzersWithBadMetadata());
         Assert.Single(host.AnalyzerReferences);
         var analyzerReference = host.AnalyzerReferences.Single();
         var analyzer = analyzerReference.GetAnalyzersForAllLanguages().Single();

--- a/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/InMemoryLoaderTests.cs
@@ -60,19 +60,14 @@ public sealed class InMemoryLoaderTests : TestBase
     [Fact]
     public void AnalyzersBadDefinition()
     {
-        var (fileName, image) = LibraryUtil.GetAnalyzersWithBadMetadata();
-        var alc = new AssemblyLoadContext("Custom", isCollectible: true);
-        var loader = new InMemoryLoader(
-            "test loader",
-            alc,
-            Path.GetFileNameWithoutExtension(fileName),
-            image.ToArray());
-        var analyzerReference = loader.AnalyzerReferences.Single();
+        var data = LibraryUtil.GetAnalyzersWithBadMetadata();
+        using var host = new BasicAnalyzerHostInMemory(data.FileName, data.Image.ToArray());
+        Assert.Single(host.AnalyzerReferences);
+        var analyzerReference = host.AnalyzerReferences.Single();
         var analyzer = analyzerReference.GetAnalyzersForAllLanguages().Single();
         Assert.Equal("GoodAnalyzer", analyzer.GetType().Name);
         var generator = analyzerReference.GetGeneratorsForAllLanguages().Single();
         Assert.Equal("GoodGenerator", TestUtil.GetGeneratorType(generator).Name);
-        loader.Unload();
     }
 
 #endif

--- a/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
@@ -25,7 +25,7 @@ public class LogReaderStateTests : TestBase
         var state = new Util.LogReaderState(baseDir: Root.NewDirectory());
         Directory.CreateDirectory(state.AnalyzerDirectory);
         state.Dispose();
-        Assert.False(Directory.Exists(state.BaseDirectory));
+        Assert.True(Directory.Exists(state.BaseDirectory));
     }
 
     /// <summary>

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -905,7 +905,7 @@ public sealed class ProgramTests : TestBase
 
         var (exitCode, output) = RunCompLogEx($"generated {dir} -a None");
         Assert.Equal(Constants.ExitSuccess, exitCode);
-        Assert.Contains("BCLA0001", output);
+        Assert.Contains(RoslynUtil.ErrorReadingGeneratedFilesDiagnosticDescriptor.Id, output);
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -252,7 +252,7 @@ public sealed class RoslynUtilTests
     [Fact]
     public void GetAnalyzerTypeDefinitions()
     {
-        var (_, image) = LibraryUtil.GetAnalyzersWithDiffAttribtueCombinations();
+        var image = LibraryUtil.GetAnalyzersWithDiffAttribtueCombinations().Image;
         using var peReader = new PEReader(image);
         var metadataReader = peReader.GetMetadataReader();
 

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -1,4 +1,5 @@
 ﻿using Basic.CompilerLog.Util;
+using Basic.CompilerLog.Util.Impl;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
@@ -25,11 +26,19 @@ public sealed class SolutionReaderTests : TestBase
 
     public override void Dispose()
     {
-        base.Dispose();
         foreach (var reader in ReaderList)
         {
             reader.Dispose();
         }
+        ReaderList.Clear();
+
+#if NET
+        // The underlying solution structure holds lots of references that root our contexts 
+        // so there is no way to fully free here.
+        OnDiskLoader.ClearActiveAssemblyLoadContext();
+#endif
+
+        base.Dispose();
     }
 
     private Solution GetSolution(string compilerLogFilePath, BasicAnalyzerKind basicAnalyzerKind)

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -113,6 +113,8 @@ public abstract class TestBase : IDisposable
             Assert.Fail("Bad assembly loads");
         }
 
+        State.Dispose();
+
 #if NET
 
         if (OnDiskLoader.AnyActiveAssemblyLoadContext)
@@ -122,13 +124,17 @@ public abstract class TestBase : IDisposable
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                Thread.Sleep(TimeSpan.FromSeconds(1));
+                Thread.Yield();
+            }
+
+            if (OnDiskLoader.AnyActiveAssemblyLoadContext)
+            {
+                OnDiskLoader.ClearActiveAssemblyLoadContext();
+                Assert.Fail("There are still active AssemblyLoadContext");
             }
         }
 
 #endif
-
-        State.Dispose();
 
         Root.Dispose();
     }

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -124,11 +124,12 @@ public abstract class TestBase : IDisposable
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                Thread.Yield();
+                Thread.Sleep(TimeSpan.FromSeconds(1));
             }
 
             if (OnDiskLoader.AnyActiveAssemblyLoadContext)
             {
+                Debugger.Break();
                 OnDiskLoader.ClearActiveAssemblyLoadContext();
                 Assert.Fail("There are still active AssemblyLoadContext");
             }

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -113,8 +113,6 @@ public abstract class TestBase : IDisposable
             Assert.Fail("Bad assembly loads");
         }
 
-        TestUtil.ClearLocalizableStringMap();
-
 #if NET
 
         if (OnDiskLoader.AnyActiveAssemblyLoadContext)

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -4,8 +4,15 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Xunit;
 using Xunit.Sdk;
+using Basic.CompilerLog.Util;
+using Basic.CompilerLog.Util.Impl;
+
+#if NET
+using System.Runtime.Loader;
+#endif
 
 namespace Basic.CompilerLog.UnitTests;
 

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -158,17 +158,4 @@ internal static class TestUtil
         var projectFile = GetProjectFile(directory);
         File.WriteAllText(projectFile, content);
     }
-
-    /// <summary>
-    /// Work around Roslyn issue that creates a strong reference to <see cref="AssemblyLoadContext"/> instances
-    /// </summary>
-    internal static void ClearLocalizableStringMap()
-    {
-        var assembly = typeof(Compilation).Assembly;
-        var type = assembly.GetType("Microsoft.CodeAnalysis.Diagnostics.AnalyzerManager+AnalyzerExecutionContext")!;
-        var field = type.GetField("s_localizableStringToException", BindingFlags.Static | BindingFlags.NonPublic)!;
-        var obj = field.GetValue(null)!;
-        var dictionary = (ImmutableDictionary<LocalizableString, Exception>)obj;
-        field.SetValue(null, ImmutableDictionary<LocalizableString, Exception>.Empty.WithComparers(dictionary.KeyComparer, dictionary.ValueComparer));
-    }
 }

--- a/src/Basic.CompilerLog.Util/BannedSymbols.txt
+++ b/src/Basic.CompilerLog.Util/BannedSymbols.txt
@@ -1,0 +1,4 @@
+M:Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetAnalyzers(System.String); Use GetAnalyzers(string, List<Diagnostic>) instead
+M:Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetAnalyzersForAllLanguages();
+M:Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGenerators(System.String); Use GetGenerators(string, List<Diagnostic>) instead
+M:Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGeneratorsForAllLanguages();

--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
@@ -18,11 +18,16 @@
     <Compile Include="..\Shared\PathUtil.cs" Link="PathUtil.cs" />
     <PackageReference Include="MessagePack" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">
+      <IncludeAssets>contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
+    <AdditionalFiles Include="BannedSymbols.txt" />
   </ItemGroup>
 
 </Project>

--- a/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
+++ b/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace Basic.CompilerLog.Util;
 

--- a/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
+++ b/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
@@ -33,6 +33,12 @@ public enum BasicAnalyzerKind
     OnDisk = 2,
 }
 
+public interface IBasicAnalyzerReference
+{
+    public ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language, List<Diagnostic> diagnostics);
+    public ImmutableArray<ISourceGenerator> GetGenerators(string language, List<Diagnostic> diagnostics);
+}
+
 /// <summary>
 /// The set of analyzers loaded for a given <see cref="Compilation"/>
 /// </summary>
@@ -49,8 +55,6 @@ public abstract class BasicAnalyzerHost : IDisposable
 #endif
         }
     }
-
-    private readonly ConcurrentQueue<Diagnostic> _diagnostics = new();
 
     public BasicAnalyzerKind Kind { get; }
     public ImmutableArray<AnalyzerReference> AnalyzerReferences
@@ -98,14 +102,6 @@ public abstract class BasicAnalyzerHost : IDisposable
         }
     }
 
-    protected void AddDiagnostic(Diagnostic diagnostic) => _diagnostics.Enqueue(diagnostic);
-
-    /// <summary>
-    /// Get the current set of diagnostics. This can change as analyzers can add them during 
-    /// execution which can happen in parallel to analysis.
-    /// </summary>
-    public List<Diagnostic> GetDiagnostics() => _diagnostics.ToList();
-
     public static bool IsSupported(BasicAnalyzerKind kind)
     {
 #if NET
@@ -138,7 +134,7 @@ public abstract class BasicAnalyzerHost : IDisposable
 
             if (!dataProvider.HasAllGeneratedFileContent(compilerCall))
             {
-                return new("Generated files not available in the PDB");
+                return new(CreateDiagnostic("Generated files not available in the PDB"));
             }
 
             try
@@ -148,9 +144,15 @@ public abstract class BasicAnalyzerHost : IDisposable
             }
             catch (Exception ex)
             {
-                return new BasicAnalyzerHostNone(ex.Message);
+                return new(CreateDiagnostic(ex.Message));
             }
         }
+
+        static Diagnostic CreateDiagnostic(string message) =>
+            Diagnostic.Create(
+                RoslynUtil.ErrorReadingGeneratedFilesDiagnosticDescriptor,
+                Location.None,
+                message);
     }
 }
 

--- a/src/Basic.CompilerLog.Util/CommonUtil.cs
+++ b/src/Basic.CompilerLog.Util/CommonUtil.cs
@@ -39,4 +39,32 @@ internal static class CommonUtil
     }
 
 #endif
+
+    /// <summary>
+    /// This is a _best effort_ attempt to delete a directory if it is empty. It returns true
+    /// in the case that at some point in the execution if this method the directory did 
+    /// not exist, false otherwise.
+    /// </summary>
+    internal static bool DeleteDirectoryIfEmpty(string directory)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (Directory.EnumerateFileSystemEntries(directory).Any())
+            {
+                return false;
+            }
+
+            Directory.Delete(directory, recursive: false);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/Basic.CompilerLog.Util/Data.cs
+++ b/src/Basic.CompilerLog.Util/Data.cs
@@ -74,4 +74,13 @@ public sealed class ResourceData(
     public override string ToString() => Name;
 }
 
+public readonly struct AssemblyFileData(string fileName, MemoryStream Image)
+{
+    public string FileName { get; } = fileName;
+    public MemoryStream Image { get; } = Image;
+
+    [ExcludeFromCodeCoverage]
+    public override string ToString() => FileName;
+}
+
 

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -18,7 +18,7 @@ namespace Basic.CompilerLog.Util.Impl;
 /// </summary>
 internal sealed class BasicAnalyzerHostInMemory : BasicAnalyzerHost
 {
-    internal InMemoryLoader Loader { get; }
+    internal InMemoryLoader Loader { get; private set; }
     protected override ImmutableArray<AnalyzerReference> AnalyzerReferencesCore => Loader.AnalyzerReferences;
 
     internal BasicAnalyzerHostInMemory(IBasicAnalyzerHostDataProvider provider, List<AnalyzerData> analyzers)
@@ -47,6 +47,7 @@ internal sealed class BasicAnalyzerHostInMemory : BasicAnalyzerHost
     protected override void DisposeCore()
     {
         Loader.Dispose();
+        Loader = null!;
     }
 }
 

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -28,6 +28,21 @@ internal sealed class BasicAnalyzerHostInMemory : BasicAnalyzerHost
         Loader = new InMemoryLoader(name, provider, analyzers);
     }
 
+#if NET
+
+    /// <summary>
+    /// This creates a new instance over a single analyzer.
+    /// </summary>
+    internal BasicAnalyzerHostInMemory(string simpleName, byte[] bytes)
+        :base(BasicAnalyzerKind.InMemory)
+    {
+        var name = $"{nameof(BasicAnalyzerHostInMemory)} - {Guid.NewGuid().ToString("N")}";
+        var loadContext = CommonUtil.GetAssemblyLoadContext();
+        Loader = new InMemoryLoader(name, loadContext, simpleName, bytes);
+    }
+
+#endif
+
     protected override void DisposeCore()
     {
         Loader.Dispose();
@@ -341,6 +356,7 @@ file sealed class BasicAnalyzerReference : AnalyzerReference, IBasicAnalyzerRefe
         return null;
     }
 
+    [ExcludeFromCodeCoverage]
     public override string ToString() => $"In Memory {AssemblyName}";
 }
 

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -33,12 +33,13 @@ internal sealed class BasicAnalyzerHostInMemory : BasicAnalyzerHost
     /// <summary>
     /// This creates a new instance over a single analyzer.
     /// </summary>
-    internal BasicAnalyzerHostInMemory(string simpleName, byte[] bytes)
+    internal BasicAnalyzerHostInMemory(AssemblyFileData assemblyFileData)
         :base(BasicAnalyzerKind.InMemory)
     {
         var name = $"{nameof(BasicAnalyzerHostInMemory)} - {Guid.NewGuid().ToString("N")}";
         var loadContext = CommonUtil.GetAssemblyLoadContext();
-        Loader = new InMemoryLoader(name, loadContext, simpleName, bytes);
+        var simpleName = Path.GetFileNameWithoutExtension(assemblyFileData.FileName);
+        Loader = new InMemoryLoader(name, loadContext, simpleName, assemblyFileData.Image.ToArray());
     }
 
 #endif

--- a/src/Basic.CompilerLog.Util/LogReaderState.cs
+++ b/src/Basic.CompilerLog.Util/LogReaderState.cs
@@ -28,6 +28,10 @@ public sealed class LogReaderState : IDisposable
     /// </summary>
     internal bool CacheAnalyzers => _analyzersMap is not null;
 
+    /// <summary>
+    /// This is the base directory that is used for any on disk assets that need to be created
+    /// by compiler logs. This is typically used for crypto key files and analyzers.
+    /// </summary>
     internal string BaseDirectory { get; }
 
     /// <summary>

--- a/src/Basic.CompilerLog.Util/LogReaderState.cs
+++ b/src/Basic.CompilerLog.Util/LogReaderState.cs
@@ -111,10 +111,9 @@ public sealed class LogReaderState : IDisposable
                 Directory.Delete(CryptoKeyFileDirectory, recursive: true);
             }
 
-            if (Directory.Exists(BaseDirectory) && !Directory.Exists(AnalyzerDirectory))
-            {
-                Directory.Delete(BaseDirectory, recursive: true);
-            }
+            // It's expected that some hosts will clean up their directories asynchronously. Both
+            // this type and the hosts need to attempt to clean up the base directory.
+            CommonUtil.DeleteDirectoryIfEmpty(BaseDirectory);
         }
         catch (Exception ex)
         {

--- a/src/Basic.CompilerLog.Util/LogReaderState.cs
+++ b/src/Basic.CompilerLog.Util/LogReaderState.cs
@@ -106,14 +106,20 @@ public sealed class LogReaderState : IDisposable
 
         try
         {
-            if (Directory.Exists(BaseDirectory))
+            if (Directory.Exists(CryptoKeyFileDirectory))
+            {
+                Directory.Delete(CryptoKeyFileDirectory, recursive: true);
+            }
+
+            if (Directory.Exists(BaseDirectory) && !Directory.Exists(AnalyzerDirectory))
             {
                 Directory.Delete(BaseDirectory, recursive: true);
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // Nothing to do if we can't delete the directories
+            Debug.Fail(ex.Message);
         }
     }
 

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -957,7 +957,7 @@ internal static class RoslynUtil
     }
 
     /// <summary>
-    /// Work around Roslyn issue that creates a strong reference to <see cref="AssemblyLoadContext"/> instances
+    /// Work around Roslyn issue that creates a strong reference to AssemblyLoadContext instances
     /// 
     /// https://github.com/dotnet/roslyn/issues/77719
     /// </summary>

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -47,26 +47,26 @@ internal static class RoslynUtil
     public static readonly DiagnosticDescriptor CannotLoadTypesDiagnosticDescriptor =
         new DiagnosticDescriptor(
             "BCLA0002",
-            "Failed to load types from assembly",
-            "Failed to load types from {0}: {1}",
+            "Failed to load analyzer",
+            "Failed to load analyzer: {0}",
             "BasicCompilerLog",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-    public static readonly DiagnosticDescriptor CannotFindAssemblyDiagnosticDescriptor =
+    public static readonly DiagnosticDescriptor CannotReadFileDiagnosticDescriptor =
         new DiagnosticDescriptor(
             "BCLA0003",
-            "Cannot find assembly",
-            "Cannot find assembly {0}",
+            "Cannot read file",
+            "Cannot read file {0}",
             "BasicCompilerLog",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-    public static readonly DiagnosticDescriptor CannotReadFileDiagnosticDescriptor =
+    public static readonly DiagnosticDescriptor ErrorReadingGeneratedFilesDiagnosticDescriptor =
         new DiagnosticDescriptor(
             "BCLA0004",
-            "Cannot read file",
-            "Cannot read file {0}",
+            "Error reading generated files",
+            "Error reading generated files: {0}",
             "BasicCompilerLog",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -497,7 +497,7 @@ int RunReplay(IEnumerable<string> args)
             WriteLine($"Outputting to {baseOutputPath}");
         }
 
-        using var reader = GetCompilerCallReader(extra, options.BasicAnalyzerKind, checkVersion: true);
+        using var reader = GetCompilerCallReader(extra, options.BasicAnalyzerKind, checkVersion: true, new(cacheAnalyzers: true));
         var compilerCalls = reader.ReadAllCompilerCalls(options.FilterCompilerCalls);
         if (compilerCalls.Count == 0)
         {
@@ -879,10 +879,10 @@ Stream GetOrCreateCompilerLogStream(List<string> extra)
     return CompilerLogUtil.GetOrCreateCompilerLogStream(logFilePath);
 }
 
-ICompilerCallReader GetCompilerCallReader(List<string> extra, BasicAnalyzerKind? basicAnalyzerKind = null, bool checkVersion = false)
+ICompilerCallReader GetCompilerCallReader(List<string> extra, BasicAnalyzerKind? basicAnalyzerKind = null, bool checkVersion = false, LogReaderState? state = null)
 {
     var logFilePath = GetLogFilePath(extra);
-    var reader = CompilerCallReaderUtil.Create(logFilePath, basicAnalyzerKind);
+    var reader = CompilerCallReaderUtil.Create(logFilePath, basicAnalyzerKind, state);
     OnCompilerCallReader(reader);
     if (reader is CompilerLogReader compilerLogReader)
     {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,6 +11,10 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(_RoslynVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(_RoslynVersion)" />

--- a/src/Scratch/Scratch.cs
+++ b/src/Scratch/Scratch.cs
@@ -28,8 +28,9 @@ using TraceReloggerLib;
 #pragma warning disable 8321
 
 //using var reader = CompilerLogReader.Create(zipFilePath);
-var filePath = @"C:\Users\jaredpar\temp\console\msbuild.binlog";
-RunComplog($"id --inline {filePath}");
+var filePath = @"/home/jaredpar/code/dotnet/artifacts/log/Release/roslyn/msca.complog";
+RunComplog($"hash export {filePath}");
+Console.WriteLine("done");
 /*
 using var reader = CompilerLogReader.Create(filePath);
 var exportUtil = new ExportUtil(reader);


### PR DESCRIPTION
When analyzers / generators produce diagnostics put it in the hash content so that it's visible in the diff