### PR TITLE
Print short name in analyzers

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -182,6 +182,25 @@ public sealed class ProgramTests : TestBase
         Assert.Contains("Generators:", output); 
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AnalyzersPath(bool includePath)
+    {
+        var arg = includePath ? "--path" : "";
+        var (exitCode, output) = RunCompLogEx($"analyzers {Fixture.ConsoleProjectPath} {arg}");
+        Assert.Equal(Constants.ExitSuccess, exitCode);
+        Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers.dll", output);
+        if (includePath)
+        {
+            Assert.Contains($"{Path.DirectorySeparatorChar}Microsoft.CodeAnalysis.NetAnalyzers.dll", output);
+        }
+        else
+        {
+            Assert.DoesNotContain($"{Path.DirectorySeparatorChar}Microsoft.CodeAnalysis.NetAnalyzers.dll", output);
+        }
+    }
+
     [Fact]
     public void BadCommand()
     {

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -126,9 +126,11 @@ int RunCreate(IEnumerable<string> args)
 int RunAnalyzers(IEnumerable<string> args)
 {
     var includeTypes = false;
+    var includePath = false;
     var options = new FilterOptionSet()
     {
         { "t|types", "include type names", o => includeTypes = o is not null },
+        { "path", "include analyzer file path", o => includePath = o is not null },
     };
 
     try
@@ -147,7 +149,8 @@ int RunAnalyzers(IEnumerable<string> args)
             WriteLine(compilerCall.GetDiagnosticName());
             foreach (var data in reader.ReadAllAnalyzerData(compilerCall))
             {
-                WriteLine($"\t{data.FilePath}");
+                var name = includePath ? data.FilePath : data.FileName;
+                WriteLine($"\t{name}");
 
                 if (includeTypes)
                 {


### PR DESCRIPTION
By defaut shift to printing short name for readability and added an explicit `--path` option to see the full paths.