### PR TITLE
Use theories in the using all compiler log tests

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -77,6 +77,32 @@ public abstract class TestBase : IDisposable
     }
 
     /// <summary>
+    /// Return the <see cref="BasicAnalyzerKind"/> paired with the name of <see cref="LogData"/> instances
+    /// from <see cref="CompilerLogFixture"/> 
+    /// </summary>
+    public static IEnumerable<object[]> GetSimpleBasicAnalyzerKindsAndLogDataNames()
+    {
+        foreach (var kind in GetSimpleBasicAnalyzerKinds())
+        {
+            foreach (var logData in CompilerLogFixture.GetAllLogDataNames())
+            {
+                yield return [kind[0], logData];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get all of the log data names from <see cref="CompilerLogFixture"/>.
+    /// </summary>
+    public static IEnumerable<object[]> GetAllLogDataNames()
+    {
+        foreach (var logData in CompilerLogFixture.GetAllLogDataNames())
+        {
+            yield return [logData];
+        }
+    }
+
+    /// <summary>
     /// This captures the set of "missing" files that we need to be tolerant of in our 
     /// reading and creation of compiler logs.
     /// </summary>
@@ -85,7 +111,7 @@ public abstract class TestBase : IDisposable
         yield return ["keyfile", "does-not-exist.snk", false]; // key file isn't noticed until emit
         yield return ["embed", "data.txt", true];
         yield return ["win32manifest", "data.manifest", false]; // manifest isn't noticed until emit
-        yield return ["win32res", "data.res", true]; 
+        yield return ["win32res", "data.res", true];
         yield return ["sourcelink", "data.link", true];
         yield return ["analyzerconfig", "data.config", true];
         yield return [null, "data.cs", true];

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -49,97 +49,82 @@ public sealed class UsingAllCompilerLogTests : TestBase
         }
     }
 
-    [Fact]
-    public async Task EmitToDisk()
+    [Theory]
+    [MemberData(nameof(GetAllLogDataNames))]
+    public async Task EmitToDisk(string logDataName)
     {
-        var list = new List<Task>();
-        await foreach (var complogPath in Fixture.GetAllCompilerLogs(TestOutputHelper))
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        var complogPath = logData.CompilerLogPath;
+        using var reader = CompilerLogReader.Create(complogPath, basicAnalyzerKind: BasicAnalyzerKind.None);
+        foreach (var data in reader.ReadAllCompilationData())
         {
-            var task = Task.Run(() => 
+            if (!reader.HasAllGeneratedFileContent(data.CompilerCall))
             {
-                using var reader = CompilerLogReader.Create(complogPath, basicAnalyzerKind: BasicAnalyzerKind.None);
-                foreach (var data in reader.ReadAllCompilationData())
-                {
-                    if (!reader.HasAllGeneratedFileContent(data.CompilerCall))
-                    {
-                        continue;
-                    }
+                continue;
+            }
 
-                    using var testDir = new TempDir();
-                    TestOutputHelper.WriteLine($"{Path.GetFileName(complogPath)}: {data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                    var emitResult = data.EmitToDisk(testDir.DirectoryPath, cancellationToken: CancellationToken);
-                    AssertEx.Success(TestOutputHelper, emitResult);
-                    Assert.NotEmpty(emitResult.Directory);
-                    Assert.NotEmpty(emitResult.AssemblyFileName);
-                    Assert.NotEmpty(emitResult.AssemblyFilePath);
+            using var testDir = new TempDir();
+            TestOutputHelper.WriteLine($"{Path.GetFileName(complogPath)}: {data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
+            var emitResult = data.EmitToDisk(testDir.DirectoryPath, cancellationToken: CancellationToken);
+            AssertEx.Success(TestOutputHelper, emitResult);
+            Assert.NotEmpty(emitResult.Directory);
+            Assert.NotEmpty(emitResult.AssemblyFileName);
+            Assert.NotEmpty(emitResult.AssemblyFilePath);
 
-                    var emitFlags = data.EmitFlags;
-                    if ((emitFlags & EmitFlags.IncludePdbStream) != 0 && data.EmitOptions.DebugInformationFormat != DebugInformationFormat.Embedded)
-                    {
-                        Assert.NotNull(emitResult.PdbFilePath);
-                    }
+            var emitFlags = data.EmitFlags;
+            if ((emitFlags & EmitFlags.IncludePdbStream) != 0 && data.EmitOptions.DebugInformationFormat != DebugInformationFormat.Embedded)
+            {
+                Assert.NotNull(emitResult.PdbFilePath);
+            }
 
-                    if ((emitFlags & EmitFlags.IncludeXmlStream) != 0)
-                    {
-                        Assert.NotNull(emitResult.XmlFilePath);
-                    }
+            if ((emitFlags & EmitFlags.IncludeXmlStream) != 0)
+            {
+                Assert.NotNull(emitResult.XmlFilePath);
+            }
 
-                    if ((emitFlags & EmitFlags.IncludeMetadataStream) != 0)
-                    {
-                        Assert.NotNull(emitResult.MetadataFilePath);
-                    }
-                }
-            }, CancellationToken);
-
-            list.Add(task);
+            if ((emitFlags & EmitFlags.IncludeMetadataStream) != 0)
+            {
+                Assert.NotNull(emitResult.MetadataFilePath);
+            }
         }
-
-        Assert.NotEmpty(list);
-        await Task.WhenAll(list);
     }
 
     /// <summary>
     /// Make sure paths for generated files don't have illegal characters when using the none host
     /// </summary>
-    /// <returns></returns>
-    [Fact]
-    public async Task GeneratedFilePathsNoneHost()
+    [Theory]
+    [MemberData(nameof(GetAllLogDataNames))]
+    public async Task GeneratedFilePathsNoneHost(string logDataName)
     {
         char[] illegalChars = ['<', '>'];
-        await foreach (var logPath in Fixture.GetAllLogs(TestOutputHelper))
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        using var reader = CompilerCallReaderUtil.Create(logData.CompilerLogPath, BasicAnalyzerKind.None);
+        foreach (var data in reader.ReadAllCompilationData(reader.HasAllGeneratedFileContent))
         {
-            TestOutputHelper.WriteLine(logPath);
-            using var reader = CompilerCallReaderUtil.Create(logPath, BasicAnalyzerKind.None);
-            foreach (var data in reader.ReadAllCompilationData(reader.HasAllGeneratedFileContent))
+            TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
+            var generatedTrees = data.GetGeneratedSyntaxTrees(CancellationToken);
+            foreach (var tree in generatedTrees)
             {
-                TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var generatedTrees = data.GetGeneratedSyntaxTrees(CancellationToken);
-                foreach (var tree in generatedTrees)
+                foreach (var c in illegalChars)
                 {
-                    foreach (var c in illegalChars)
-                    {
-                        Assert.DoesNotContain(c, tree.FilePath);
-                    }
+                    Assert.DoesNotContain(c, tree.FilePath);
                 }
             }
         }
     }
 
     [Theory]
-    [MemberData(nameof(GetSimpleBasicAnalyzerKinds))]
-    public async Task EmitToMemory(BasicAnalyzerKind basicAnalyzerKind)
+    [MemberData(nameof(GetSimpleBasicAnalyzerKindsAndLogDataNames))]
+    public async Task EmitToMemory(BasicAnalyzerKind basicAnalyzerKind, string logDataName)
     {
-        TestOutputHelper.WriteLine($"BasicAnalyzerKind: {basicAnalyzerKind}");
-        await foreach (var logPath in Fixture.GetAllLogs(TestOutputHelper))
+        TestOutputHelper.WriteLine($"BasicAnalyzerKind: {basicAnalyzerKind}, LogDataName: {logDataName}");
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        using var reader = CompilerCallReaderUtil.Create(logData.CompilerLogPath, basicAnalyzerKind);
+        foreach (var data in reader.ReadAllCompilationData(cc => basicAnalyzerKind != BasicAnalyzerKind.None || reader.HasAllGeneratedFileContent(cc)))
         {
-            TestOutputHelper.WriteLine(logPath);
-            using var reader = CompilerCallReaderUtil.Create(logPath, basicAnalyzerKind);
-            foreach (var data in reader.ReadAllCompilationData(cc => basicAnalyzerKind != BasicAnalyzerKind.None || reader.HasAllGeneratedFileContent(cc)))
-            {
-                TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var emitResult = data.EmitToMemory(cancellationToken: CancellationToken);
-                AssertEx.Success(TestOutputHelper, emitResult);
-            }
+            TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
+            var emitResult = data.EmitToMemory(cancellationToken: CancellationToken);
+            AssertEx.Success(TestOutputHelper, emitResult);
         }
     }
 
@@ -147,27 +132,30 @@ public sealed class UsingAllCompilerLogTests : TestBase
     /// Use a <see cref="Util.LogReaderState"/> and dispose the reader before using the <see cref="CompilationData"/>.
     /// This helps prove that we don't maintain accidental references into the reader when doing Emit
     /// </summary>
-    [Fact]
-    public async Task EmitToMemoryCompilerLogWithSeparateState()
+    [Theory]
+    [MemberData(nameof(GetAllLogDataNames))]
+    public async Task EmitToMemoryCompilerLogWithSeparateState(string logDataName)
     {
-        await foreach (var complogPath in Fixture.GetAllCompilerLogs(TestOutputHelper, BasicAnalyzerKind.None))
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        if (!logData.SupportsNoneHost)
         {
-            TestOutputHelper.WriteLine(complogPath);
-            using var state = new Util.LogReaderState(baseDir: Root.NewDirectory());
-            foreach (var data in ReadAll(complogPath, state))
-            {
-                // Cannot replay metadata only with a None host. There is no PDB from which generated source files
-                // can be read.
-                if (data.EmitOptions.EmitMetadataOnly)
-                {
-                    continue;
-                }
+            return;
+        }
 
-                TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var emitResult = data.EmitToMemory(cancellationToken: CancellationToken);
-                TestOutputHelper.WriteLine(string.Join(Environment.NewLine, emitResult.Diagnostics.Select(d => d.ToString())));
-                AssertEx.Success(TestOutputHelper, emitResult);
+        using var state = new Util.LogReaderState(baseDir: Root.NewDirectory());
+        foreach (var data in ReadAll(logData.CompilerLogPath, state))
+        {
+            // Cannot replay metadata only with a None host. There is no PDB from which generated source files
+            // can be read.
+            if (data.EmitOptions.EmitMetadataOnly)
+            {
+                continue;
             }
+
+            TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
+            var emitResult = data.EmitToMemory(cancellationToken: CancellationToken);
+            TestOutputHelper.WriteLine(string.Join(Environment.NewLine, emitResult.Diagnostics.Select(d => d.ToString())));
+            AssertEx.Success(TestOutputHelper, emitResult);
         }
 
         static List<CompilationData> ReadAll(string complogPath, Util.LogReaderState state)
@@ -177,28 +165,26 @@ public sealed class UsingAllCompilerLogTests : TestBase
         }
     }
 
-    [Fact]
-    public async Task CommandLineArguments()
+    [Theory]
+    [MemberData(nameof(GetAllLogDataNames))]
+    public async Task CommandLineArguments(string logDataName)
     {
-        await foreach (var complogPath in Fixture.GetAllCompilerLogs(TestOutputHelper))
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        using var reader = CompilerLogReader.Create(logData.CompilerLogPath, basicAnalyzerKind: BasicAnalyzerKind.None);
+        foreach (var data in reader.ReadAllCompilerCalls())
         {
-            TestOutputHelper.WriteLine(complogPath);
-            using var reader = CompilerLogReader.Create(complogPath, basicAnalyzerKind: BasicAnalyzerKind.None);
-            foreach (var data in reader.ReadAllCompilerCalls())
+            var fileName = Path.GetFileName(logData.CompilerLogPath);
+            if (fileName is "windows-console.complog" ||
+                fileName is "linux-console.complog")
             {
-                var fileName = Path.GetFileName(complogPath);
-                if (fileName is "windows-console.complog" ||
-                    fileName is "linux-console.complog")
-                {
-                    Assert.Null(data.CompilerFilePath);
-                }
-                else
-                {
-                    Assert.NotNull(data.CompilerFilePath);
-                }
-                
-                Assert.NotEmpty(data.GetArguments());
+                Assert.Null(data.CompilerFilePath);
             }
+            else
+            {
+                Assert.NotNull(data.CompilerFilePath);
+            }
+            
+            Assert.NotEmpty(data.GetArguments());
         }
     }
 
@@ -268,29 +254,27 @@ public sealed class UsingAllCompilerLogTests : TestBase
     /// on disk loader. The in memory loader has a lot of custom logic and need to
     /// verify it stays in sync with the disk versions
     /// </summary>
-    [Fact]
-    public async Task VerifyAnalyzerConsistency()
+    [Theory]
+    [MemberData(nameof(GetAllLogDataNames))]
+    public async Task VerifyAnalyzerConsistency(string logDataName)
     {
-        await foreach (var logData in Fixture.GetAllLogData(TestOutputHelper))
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        using var diskReader = CompilerLogReader.Create(logData.CompilerLogPath, BasicAnalyzerKind.OnDisk);
+        var diskDataList = diskReader.ReadAllCompilationData();
+        using var memoryReader = CompilerLogReader.Create(logData.CompilerLogPath, BasicAnalyzerKind.InMemory);
+        var memoryDataList = memoryReader.ReadAllCompilationData();
+        Assert.Equal(diskDataList.Count, memoryDataList.Count);
+        for (int i = 0; i < diskDataList.Count; i++)
         {
-            TestOutputHelper.WriteLine(logData.CompilerLogPath);
-            using var diskReader = CompilerLogReader.Create(logData.CompilerLogPath, BasicAnalyzerKind.OnDisk);
-            var diskDataList = diskReader.ReadAllCompilationData();
-            using var memoryReader = CompilerLogReader.Create(logData.CompilerLogPath, BasicAnalyzerKind.InMemory);
-            var memoryDataList = memoryReader.ReadAllCompilationData();
-            Assert.Equal(diskDataList.Count, memoryDataList.Count);
-            for (int i = 0; i < diskDataList.Count; i++)
-            {
-                var diskData = diskDataList[i];
-                var memoryData = memoryDataList[i];
+            var diskData = diskDataList[i];
+            var memoryData = memoryDataList[i];
 
-                var diskAnalyzers = diskData.AnalyzerReferences;
-                var memoryAnalyzers = memoryData.AnalyzerReferences;
-                Assert.Equal(diskAnalyzers.Length, memoryAnalyzers.Length);
-                for (int j = 0; j < diskAnalyzers.Length; j++)
-                {
-                    AssertCore(diskAnalyzers[j], memoryAnalyzers[j]);
-                }
+            var diskAnalyzers = diskData.AnalyzerReferences;
+            var memoryAnalyzers = memoryData.AnalyzerReferences;
+            Assert.Equal(diskAnalyzers.Length, memoryAnalyzers.Length);
+            for (int j = 0; j < diskAnalyzers.Length; j++)
+            {
+                AssertCore(diskAnalyzers[j], memoryAnalyzers[j]);
             }
         }
 
@@ -322,35 +306,34 @@ public sealed class UsingAllCompilerLogTests : TestBase
     /// argument parsing. This will also catch cases where new values are added to the options 
     /// that are not being set by our code base.
     /// </summary>
-    [Fact]
-    public async Task VerifyConsistentOptions()
+    [Theory]
+    [MemberData(nameof(GetAllLogDataNames))]
+    public async Task VerifyConsistentOptions(string logDataName)
     {
-        await foreach (var logData in Fixture.GetAllLogData(TestOutputHelper))
+        var logData = await Fixture.GetLogDataByName(logDataName, TestOutputHelper);
+        if (logData.BinaryLogPath is null)
         {
-            if (logData.BinaryLogPath is null)
-            {
-                continue;
-            }
+            return;
+        }
 
-            using var complogReader = CompilerLogReader.Create(logData.CompilerLogPath);
-            using var binlogReader = BinaryLogReader.Create(logData.BinaryLogPath);
-            var complogDataList = complogReader.ReadAllCompilationData();
-            var binlogDataList = binlogReader.ReadAllCompilationData();
-            Assert.Equal(complogDataList.Count, binlogDataList.Count);
-            for (int i = 0; i < complogDataList.Count; i++)
-            {
-                Assert.Equal(complogDataList[i].EmitOptions, binlogDataList[i].EmitOptions);
-                Assert.Equal(complogDataList[i].ParseOptions, binlogDataList[i].ParseOptions);
+        using var complogReader = CompilerLogReader.Create(logData.CompilerLogPath);
+        using var binlogReader = BinaryLogReader.Create(logData.BinaryLogPath);
+        var complogDataList = complogReader.ReadAllCompilationData();
+        var binlogDataList = binlogReader.ReadAllCompilationData();
+        Assert.Equal(complogDataList.Count, binlogDataList.Count);
+        for (int i = 0; i < complogDataList.Count; i++)
+        {
+            Assert.Equal(complogDataList[i].EmitOptions, binlogDataList[i].EmitOptions);
+            Assert.Equal(complogDataList[i].ParseOptions, binlogDataList[i].ParseOptions);
 
-                var complogOptions = Normalize(complogDataList[i].CompilationOptions);
-                var binlogOptions = Normalize(binlogDataList[i].CompilationOptions);
-                Assert.Equal(complogOptions, binlogOptions);
+            var complogOptions = Normalize(complogDataList[i].CompilationOptions);
+            var binlogOptions = Normalize(binlogDataList[i].CompilationOptions);
+            Assert.Equal(complogOptions, binlogOptions);
 
-                CompilationOptions Normalize(CompilationOptions options) => options
-                    .WithCryptoKeyFile(null)
-                    .WithStrongNameProvider(null)
-                    .WithSyntaxTreeOptionsProvider(null);
-            }
+            CompilationOptions Normalize(CompilationOptions options) => options
+                .WithCryptoKeyFile(null)
+                .WithStrongNameProvider(null)
+                .WithSyntaxTreeOptionsProvider(null);
         }
     }
 }


### PR DESCRIPTION
This will make the tests significantly easier to debug, particularly when they fail in CI.