### PR TITLE
Fix version not being included in the package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Build 
-        run: dotnet build -c Release 
+      - name: Build
+        # Need to pass PackageVersion because it's embedded into the DLL.
+        run: dotnet build -c Release -p:PackageVersion="${{ github.event.inputs.version }}"
 
       - name: Pack Basic.CompilerLog.Util
         run: dotnet pack --no-build -p:IncludeSymbols=false -p:RepositoryCommit=${GITHUB_SHA} -p:PackageVersion="${{ github.event.inputs.version }}" -c Release src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj -o .


### PR DESCRIPTION
Try running `complog help` with the latest package version. You will get

```
complog [command] [args]
version: 42.42.42.42
```

whereas after this PR is merged and released you should get

```
complog [command] [args]
version: 0.9.14.0
```