### PR TITLE
Use natural sort to select the best SDK

### DIFF
--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" VersionOverride="$(RoslynReferenceVersion)" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="MSBuild.StructuredLogger" />
+    <PackageReference Include="NaturalSort.Extension" />
     <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
     <AdditionalFiles Include="BannedSymbols.txt" />
   </ItemGroup>

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
+using NaturalSort.Extension;
 
 namespace Basic.CompilerLog.Util;
 
@@ -135,7 +136,7 @@ public sealed partial class ExportUtil
             WriteBuildCmd(sdkDir, cmdFileName);
         }
 
-        string? bestSdkDir = sdkDirectories.OrderByDescending(x => x, PathUtil.Comparer).FirstOrDefault();
+        string? bestSdkDir = sdkDirectories.OrderByDescending(x => x, PathUtil.Comparer.WithNaturalSort()).FirstOrDefault();
         if (bestSdkDir is not null)
         {
             WriteBuildCmd(bestSdkDir, "build");

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.14.1" />
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.45" />
+    <PackageVersion Include="NaturalSort.Extension" Version="4.3.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
Without this, complog selects 9.0 sdk over 10.0. That's also impacting my ability to run ExportUtil tests locally because they use 10 sdk for building but then run against 9 sdk, failing with "lang version 14 is not valid".