### PR TITLE
Suppress warning about missing package sources

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <!-- We are not using package source mapping. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
     <_RoslynVersion>4.14.0</_RoslynVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The warning is pretty annoying:

<img width="1306" height="378" alt="image" src="https://github.com/user-attachments/assets/bcee5560-ad77-4159-bcd4-6b7b654134b5" />
