### PR TITLE
Avoid exporting `/sourcelink` absolute path

### DIFF
--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -211,6 +211,7 @@ public sealed partial class ExportUtil
                     span.StartsWith("embed", comparison) ||
                     span.StartsWith("resource", comparison) ||
                     span.StartsWith("linkresource", comparison) ||
+                    span.StartsWith("sourcelink", comparison) ||
                     span.StartsWith("ruleset", comparison) ||
                     span.StartsWith("keyfile", comparison) ||
                     span.StartsWith("link", comparison))


### PR DESCRIPTION
`/sourcelink` is handled in the code path which copies source files and rewrites the paths, but it wasn't skipped here, leading to the exported rsp containing both the original `/sourcelink` (with absolute path to the machine where the complog was collected) and the rewritten `/sourcelink` (the correct one, no changes to that one in this PR).