### PR TITLE
Handle invalid versions in sdk directory

### DIFF
--- a/src/Basic.CompilerLog.App/Extensions.cs
+++ b/src/Basic.CompilerLog.App/Extensions.cs
@@ -14,7 +14,7 @@ internal static class Extensions
     internal static string GetFailureString(this Exception ex)
     {
         var builder = new StringBuilder();
-        builder.AppendLine(ex.Message);
+        builder.AppendLine($"{ex.GetType()}: {ex.Message}");
         builder.AppendLine(ex.StackTrace);
 
         while (ex.InnerException is { } inner)

--- a/src/Basic.CompilerLog.Util/SdkUtil.cs
+++ b/src/Basic.CompilerLog.Util/SdkUtil.cs
@@ -72,7 +72,11 @@ public static class SdkUtil
                 continue;
             }
 
-            var version = new Version(versionStr);
+            if (!Version.TryParse(versionStr, out var version))
+            {
+                continue;
+            }
+
             var sdkDir = Path.Combine(dir, "Roslyn", "bincore");
             if (Directory.Exists(sdkDir))
             {


### PR DESCRIPTION
Fixes this error I just got:

<p><img width="3461" height="819" alt="image" src="https://github.com/user-attachments/assets/41e40929-93b8-4f23-8d23-c93c7a5a50a6" />

(Turns out I have `C:\Program Files\dotnet\sdk\NuGetFallbackFolder` for some reason which fails to parse.)