### PR TITLE
Include diagnostics in CompilerLogException message

### DIFF
--- a/src/Basic.CompilerLog.Util/CompilerLogException.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogException.cs
@@ -1,8 +1,6 @@
-using Microsoft.Build.Logging.StructuredLogger;
-
 namespace Basic.CompilerLog.Util;
 
-public sealed class CompilerLogException(string message, List<string>? diagnostics = null) : Exception(message)
+public sealed class CompilerLogException(string message, List<string>? diagnostics = null) : Exception(message + (diagnostics is [..] ? ("\n" + string.Join("\n", diagnostics)) : ""))
 {
     public IReadOnlyList<string> Diagnostics { get; } = diagnostics ?? (IReadOnlyList<string>)Array.Empty<string>();
 }


### PR DESCRIPTION
Before:
<p><img width="3799" height="940" alt="image" src="https://github.com/user-attachments/assets/9ba661e2-8735-424f-b0dd-c89b333404b6" />


After:
<p>
<img width="3781" height="989" alt="image" src="https://github.com/user-attachments/assets/13d49e7d-9c97-4820-9937-086cc8f029ff" />
