### PR TITLE
Handle pre-release SDK versions

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/SdkUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SdkUtilTests.cs
@@ -1,5 +1,5 @@
-
 using Basic.CompilerLog.Util;
+using NuGet.Versioning;
 using Xunit;
 using Xunit.Sdk;
 
@@ -11,5 +11,24 @@ public sealed class SdkUtilTests
     public void GetDotnetDirectoryBadPath()
     {
         Assert.Throws<Exception>(() => SdkUtil.GetDotnetDirectory(@"C:\"));
+    }
+
+    [Fact]
+    public void SdkVersions()
+    {
+        using var temp = new TempDir();
+        var a = Path.GetFullPath(Path.Combine(temp.NewDirectory("sdk/9.0.100/Roslyn/bincore"), "../.."));
+        var b = Path.GetFullPath(Path.Combine(temp.NewDirectory("sdk/10.0.100-rc.2.25502.107/Roslyn/bincore"), "../.."));
+        temp.NewDirectory("sdk/invalid-version");
+        var sdks = SdkUtil.GetSdkDirectoriesAndVersion(temp.DirectoryPath);
+        Assert.Equal(
+            [
+                (a, new NuGetVersion(9, 0, 100)),
+                (b, new NuGetVersion(10, 0, 100, "rc.2.25502.107")),
+            ],
+            sdks.OrderBy(t => t.SdkVersion));
+
+        var latestSdk = SdkUtil.GetLatestSdkDirectories(temp.DirectoryPath);
+        Assert.Equal((b, new NuGetVersion(10, 0, 100, "rc.2.25502.107")), latestSdk);
     }
 }

--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="NaturalSort.Extension" />
+    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
     <AdditionalFiles Include="BannedSymbols.txt" />
   </ItemGroup>

--- a/src/Basic.CompilerLog.Util/SdkUtil.cs
+++ b/src/Basic.CompilerLog.Util/SdkUtil.cs
@@ -1,14 +1,5 @@
-using Microsoft.Build.Logging.StructuredLogger;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Configuration.Internal;
-using System.Diagnostics;
-using System.Linq;
+using NuGet.Versioning;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Basic.CompilerLog.Util;
 
@@ -59,20 +50,15 @@ public static class SdkUtil
             .Select(x => x.SdkDirectory)
             .ToList();
 
-    public static List<(string SdkDirectory, Version SdkVersion)> GetSdkDirectoriesAndVersion(string? dotnetDirectory = null)
+    public static List<(string SdkDirectory, NuGetVersion SdkVersion)> GetSdkDirectoriesAndVersion(string? dotnetDirectory = null)
     {
         dotnetDirectory ??= GetDotnetDirectory();
         var sdk = Path.Combine(dotnetDirectory, "sdk");
-        var sdks = new List<(string, Version)>();
+        var sdks = new List<(string, NuGetVersion)>();
         foreach (var dir in Directory.EnumerateDirectories(sdk))
         {
             var versionStr = Path.GetFileName(dir)!;
-            if (versionStr.Contains('-'))
-            {
-                continue;
-            }
-
-            if (!Version.TryParse(versionStr, out var version))
+            if (!NuGetVersion.TryParse(versionStr, out var version))
             {
                 continue;
             }
@@ -87,7 +73,7 @@ public static class SdkUtil
         return sdks;
     }
 
-    public static (string SdkDirectory, Version SdkVersion) GetLatestSdkDirectories(string? dotnetDirectory = null) =>
+    public static (string SdkDirectory, NuGetVersion SdkVersion) GetLatestSdkDirectories(string? dotnetDirectory = null) =>
         GetSdkDirectoriesAndVersion(dotnetDirectory)
             .OrderByDescending(x => x.SdkVersion)
             .First();

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.71" />
     <PackageVersion Include="NaturalSort.Extension" Version="4.4.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
This regressed with https://github.com/jaredpar/complog/pull/288 which started skipping versions with a dash in them (in `SdkUtil.cs`)