### PR TITLE
Use parsed SDK versions instead of natural sort

### DIFF
--- a/src/Basic.CompilerLog.App/CompilerLogApp.cs
+++ b/src/Basic.CompilerLog.App/CompilerLogApp.cs
@@ -535,7 +535,6 @@ public sealed class CompilerLogApp(
             using var reader = GetCompilerCallReader(extra, options.BasicAnalyzerKind, checkVersion: true, new(cacheAnalyzers: true));
             var compilerCalls = ReadAllCompilerCalls(reader, options.FilterCompilerCalls);
             var compilerCallNames = GetCompilerCallNames(compilerCalls);
-            var sdkDirs = SdkUtil.GetSdkDirectories();
             var success = true;
 
             for (int i = 0; i < compilerCalls.Count; i++)

--- a/src/Basic.CompilerLog.UnitTests/SdkUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SdkUtilTests.cs
@@ -20,7 +20,7 @@ public sealed class SdkUtilTests
         var a = Path.GetFullPath(Path.Combine(temp.NewDirectory("sdk/9.0.100/Roslyn/bincore"), "../.."));
         var b = Path.GetFullPath(Path.Combine(temp.NewDirectory("sdk/10.0.100-rc.2.25502.107/Roslyn/bincore"), "../.."));
         temp.NewDirectory("sdk/invalid-version");
-        var sdks = SdkUtil.GetSdkDirectoriesAndVersion(temp.DirectoryPath);
+        var sdks = SdkUtil.GetSdkDirectories(temp.DirectoryPath);
         Assert.Equal(
             [
                 (a, new NuGetVersion(9, 0, 100)),

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -128,7 +128,7 @@ public abstract class TestBase : IDisposable
         ];
 
         var compilerDirs = SdkUtil
-            .GetSdkDirectoriesAndVersion()
+            .GetSdkDirectories()
             .OrderByDescending(x => x.SdkVersion)
             .Where(x => versions.Any(v => x.SdkVersion.ToString().StartsWith(v)))
             .Select(x => Path.Combine(x.SdkDirectory, "Roslyn", "bincore"))

--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" VersionOverride="$(RoslynReferenceVersion)" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="MSBuild.StructuredLogger" />
-    <PackageReference Include="NaturalSort.Extension" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
     <AdditionalFiles Include="BannedSymbols.txt" />

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -1,10 +1,8 @@
-using System.Text.RegularExpressions;
-using System.Runtime.InteropServices;
-using NaturalSort.Extension;
-using Microsoft.CodeAnalysis.Text;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using NuGet.Versioning;
 
 namespace Basic.CompilerLog.Util;
 
@@ -106,7 +104,7 @@ public sealed partial class ExportUtil
         ExcludeAnalyzers = excludeAnalyzers;
     }
 
-    public void ExportAll(string destinationDir, IEnumerable<string> sdkDirectories, Func<CompilerCall, bool>? predicate = null)
+    public void ExportAll(string destinationDir, IEnumerable<(string SdkDirectory, NuGetVersion SdkVersion)> sdkDirectories, Func<CompilerCall, bool>? predicate = null)
     {
         predicate ??= static _ => true;
         for (int  i = 0; i < Reader.Count ; i++)
@@ -121,7 +119,7 @@ public sealed partial class ExportUtil
         }
     }
 
-    public void Export(CompilerCall compilerCall, string destinationDir, IEnumerable<string> sdkDirectories)
+    public void Export(CompilerCall compilerCall, string destinationDir, IEnumerable<(string SdkDirectory, NuGetVersion SdkVersion)> sdkDirectories)
     {
         if (!Path.IsPathRooted(destinationDir))
         {
@@ -152,11 +150,11 @@ public sealed partial class ExportUtil
             // Need to create a few directories so that the builds will actually function
             foreach (var sdkDir in sdkDirectories)
             {
-                var cmdFileName = $"build-{Path.GetFileName(sdkDir)}";
-                WriteBuildCmd(sdkDir, cmdFileName);
+                var cmdFileName = $"build-{Path.GetFileName(sdkDir.SdkDirectory)}";
+                WriteBuildCmd(sdkDir.SdkDirectory, cmdFileName);
             }
 
-            string? bestSdkDir = sdkDirectories.OrderByDescending(x => x, PathUtil.Comparer.WithNaturalSort()).FirstOrDefault();
+            string? bestSdkDir = sdkDirectories.OrderByDescending(x => x.SdkVersion).Select(x => x.SdkDirectory).FirstOrDefault();
             if (bestSdkDir is not null)
             {
                 WriteBuildCmd(bestSdkDir, "build");

--- a/src/Basic.CompilerLog.Util/SdkUtil.cs
+++ b/src/Basic.CompilerLog.Util/SdkUtil.cs
@@ -45,12 +45,7 @@ public static class SdkUtil
         }
     }
 
-    public static List<string> GetSdkDirectories(string? dotnetDirectory = null) =>
-        GetSdkDirectoriesAndVersion(dotnetDirectory)
-            .Select(x => x.SdkDirectory)
-            .ToList();
-
-    public static List<(string SdkDirectory, NuGetVersion SdkVersion)> GetSdkDirectoriesAndVersion(string? dotnetDirectory = null)
+    public static List<(string SdkDirectory, NuGetVersion SdkVersion)> GetSdkDirectories(string? dotnetDirectory = null)
     {
         dotnetDirectory ??= GetDotnetDirectory();
         var sdk = Path.Combine(dotnetDirectory, "sdk");
@@ -74,7 +69,7 @@ public static class SdkUtil
     }
 
     public static (string SdkDirectory, NuGetVersion SdkVersion) GetLatestSdkDirectories(string? dotnetDirectory = null) =>
-        GetSdkDirectoriesAndVersion(dotnetDirectory)
+        GetSdkDirectories(dotnetDirectory)
             .OrderByDescending(x => x.SdkVersion)
             .First();
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -25,7 +25,6 @@
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="18.0.0" />
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.71" />
-    <PackageVersion Include="NaturalSort.Extension" Version="4.4.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />


### PR DESCRIPTION
Before this PR, the generated `build.cmd` references 10-rc2 SDK even though the newer 10-ga SDK is available.