### PR TITLE
Fix double-escaped path in TryGetCompilerInvocation

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/RoslynUtilTests.cs
@@ -668,7 +668,8 @@ public sealed class RoslynUtilTests
         var result = RoslynUtil.TryGetCompilerInvocation(dirWithSpaces, isCSharp, out var invocation);
         Assert.True(result);
         Assert.NotNull(invocation);
-        Assert.Contains("\"", invocation);
-        Assert.Contains(dllName, invocation);
+
+        var expectedDllPath = Path.Combine(dirWithSpaces, dllName);
+        Assert.Equal($@"dotnet exec ""{expectedDllPath}""", invocation);
     }
 }

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -1154,7 +1154,7 @@ public static class RoslynUtil
         var dllPath = Path.Combine(compilerDirectory, dllName);
         if (File.Exists(dllPath))
         {
-            invocation = $@"dotnet exec ""{MaybeQuote(dllPath)}""";
+            invocation = $@"dotnet exec ""{dllPath}""";
             return true;
         }
 


### PR DESCRIPTION
Fixes https://github.com/jaredpar/complog/issues/347.