### PR TITLE
Fix cross-OS R2R analyzer loading in export path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance for AI assistants working with the complog (Compiler
 
 ## Project Overview
 
-**complog** is a .NET tool and library for creating, consuming, and analyzing compiler log files. These files are built from MSBuild binary logs and contain everything needed to recreate Roslyn `Compilation` instances. The project is licensed under MIT.
+**complog** is a .NET tool and library for creating, consuming, and analyzing compiler log files. These files that end with the extension `.complog` that are built from MSBuild binary logs and contain everything needed to recreate Roslyn `Compilation` instances. The project is licensed under MIT.
 
 Repository: https://github.com/jaredpar/complog
 
@@ -23,6 +23,9 @@ dotnet test src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj -
 
 # Run tests for net10.0 framework
 dotnet test src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj --framework net10.0
+
+# Run tests with blame-hang to detect hanging tests (always use this when running full suite)
+dotnet test src/Basic.CompilerLog.UnitTests/Basic.CompilerLog.UnitTests.csproj --framework net10.0 --blame-hang --blame-hang-timeout 60s
 
 # Build with binary log (used for CI and dogfooding)
 dotnet build -bl

--- a/src/Basic.CompilerLog.App/CompilerLogApp.cs
+++ b/src/Basic.CompilerLog.App/CompilerLogApp.cs
@@ -407,6 +407,7 @@ public sealed class CompilerLogApp(
         var exportOptions = ExportOptions.None;
         var useVisualStudio = false;
         var exportAsSolution = false;
+        bool? stripReadyToRun = null;
         var options = new FilterOptionSet()
         {
             { "o|out=", "path to export build content", o => baseOutputPath = o },
@@ -415,6 +416,7 @@ public sealed class CompilerLogApp(
             { "simple", "create the simplest possible export (excludes analyzers and config)", i => { if (i is not null) exportOptions |= ExportOptions.ExcludeAll; } },
             { "vs", "use the csc.exe from installed Visual Studio instances", v => useVisualStudio = v is not null },
             { "solution", "export as a full solution with project files (EXPERIMENTAL)", p => exportAsSolution = p is not null },
+            { "strip=", "strip R2R native code from analyzers: auto (default), always, never", void (string s) => stripReadyToRun = FilterOptionSet.ParseStripReadyToRun(s) },
         };
 
         try
@@ -434,7 +436,7 @@ public sealed class CompilerLogApp(
             }
 
             using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
-            using var reader = GetCompilerLogReader(compilerLogStream, leaveOpen: true, BasicAnalyzerKind.None);
+            using var reader = GetCompilerLogReader(compilerLogStream, leaveOpen: true, BasicAnalyzerKind.None, state: new LogReaderState(stripReadyToRun: stripReadyToRun));
             var exportUtil = new ExportUtil(reader, exportOptions);
 
             if (exportAsSolution)
@@ -1042,9 +1044,9 @@ public sealed class CompilerLogApp(
         }
     }
 
-    internal CompilerLogReader GetCompilerLogReader(Stream compilerLogStream, bool leaveOpen, BasicAnalyzerKind? basicAnalyzerKind = null, bool checkVersion = false)
+    internal CompilerLogReader GetCompilerLogReader(Stream compilerLogStream, bool leaveOpen, BasicAnalyzerKind? basicAnalyzerKind = null, bool checkVersion = false, LogReaderState? state = null)
     {
-        var reader = CompilerLogReader.Create(compilerLogStream, basicAnalyzerKind, state: null, leaveOpen);
+        var reader = CompilerLogReader.Create(compilerLogStream, basicAnalyzerKind, state: state, leaveOpen);
         OnCompilerCallReader(reader);
         CheckCompilerLogReader(reader, checkVersion);
         return reader;

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -223,6 +223,42 @@ public sealed class ExportUtilTests : TestBase
     /// Make sure that global configs get their full paths mapped to the new location on disk
     /// </summary>
     [Fact]
+    public void ExportedAnalyzersAreNotR2R()
+    {
+        using var reader = CompilerLogReader.Create(
+            Fixture.Console.Value.CompilerLogPath,
+            BasicAnalyzerKind.None,
+            new LogReaderState(stripReadyToRun: true));
+        var exportUtil = new ExportUtil(reader);
+        var compilerDirectories = SdkUtil.GetSdkCompilerDirectories();
+        foreach (var compilerCall in reader.ReadAllCompilerCalls())
+        {
+            using var tempDir = new TempDir();
+            exportUtil.Export(compilerCall, tempDir.DirectoryPath, compilerDirectories);
+
+            var analyzerDir = Path.Combine(tempDir.DirectoryPath, "analyzers");
+            if (!Directory.Exists(analyzerDir))
+            {
+                continue;
+            }
+
+            var dlls = Directory.GetFiles(analyzerDir, "*.dll", SearchOption.AllDirectories);
+            Assert.NotEmpty(dlls);
+
+            foreach (var dll in dlls)
+            {
+                var bytes = File.ReadAllBytes(dll);
+                Assert.False(
+                    R2RUtil.IsReadyToRun(bytes),
+                    $"Exported analyzer {Path.GetFileName(dll)} should not contain R2R native code");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Make sure that global configs get their full paths mapped to the new location on disk
+    /// </summary>
+    [Fact]
     public void GlobalConfigMapsPaths()
     {
         TestExportRsp(Fixture.ConsoleComplex.Value.CompilerLogPath, expectedCount: 1, verifyExportCallback: void (string path) =>

--- a/src/Basic.CompilerLog.UnitTests/R2RUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/R2RUtilTests.cs
@@ -378,29 +378,27 @@ public sealed class R2RUtilTests : TestBase
             BasicAnalyzerKind.None);
         var analyzerDataList = reader.ReadAllAnalyzerData(0);
 
-        // Find R2R analyzers with a standard architecture machine value (e.g. Amd64).
-        // These are Windows R2R images that need stripping on non-Windows hosts.
-        var windowsR2rData = analyzerDataList
-            .Where(a =>
-            {
-                var bytes = reader.GetAssemblyBytes(a.Mvid);
-                if (!R2RUtil.IsReadyToRun(bytes))
-                {
-                    return false;
-                }
+        // Get any R2R analyzer from the fixture (on Linux these will have machine 0xFD1D)
+        var r2rAnalyzer = analyzerDataList
+            .First(a => R2RUtil.IsReadyToRun(reader.GetAssemblyBytes(a.Mvid)));
 
-                using var stream = bytes.AsSimpleMemoryStream(writable: false);
-                using var peReader = new PEReader(stream);
-                var machine = peReader.PEHeaders.CoffHeader.Machine;
-                return machine == Machine.Amd64 || machine == Machine.Arm64;
-            })
-            .ToList();
+        var bytes = reader.GetAssemblyBytes(r2rAnalyzer.Mvid);
 
-        foreach (var data in windowsR2rData)
-        {
-            var bytes = reader.GetAssemblyBytes(data.Mvid);
-            Assert.True(R2RUtil.NeedsStripping(bytes), $"Windows R2R analyzer {data.FilePath} should need stripping on non-Windows");
-        }
+        // Patch the COFF Machine field to Machine.Amd64 (0x8664) to simulate a Windows R2R
+        // assembly being loaded on Linux. The Machine field is at offset PE_SIGNATURE + 4 in
+        // the COFF header.
+        var patchedBytes = (byte[])bytes.Clone();
+        var peSignatureOffset = BitConverter.ToInt32(patchedBytes, 0x3C);
+        var machineOffset = peSignatureOffset + 4; // PE signature is 4 bytes, Machine is first field of COFF header
+        patchedBytes[machineOffset] = 0x64;     // low byte of 0x8664 (Machine.Amd64)
+        patchedBytes[machineOffset + 1] = 0x86; // high byte
+
+        // Verify the patched assembly is still detected as R2R
+        Assert.True(R2RUtil.IsReadyToRun(patchedBytes));
+
+        // On Linux/macOS, NeedsStripping should return true because Machine.Amd64 is not the
+        // OS-native R2R sentinel
+        Assert.True(R2RUtil.NeedsStripping(patchedBytes));
     }
 
     /// <summary>

--- a/src/Basic.CompilerLog.UnitTests/R2RUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/R2RUtilTests.cs
@@ -365,6 +365,45 @@ public sealed class R2RUtilTests : TestBase
     }
 
     /// <summary>
+    /// On non-Windows hosts, a ReadyToRun assembly with a standard architecture machine value
+    /// (e.g. <see cref="Machine.Amd64"/>) is a Windows R2R image whose native code cannot
+    /// execute on the current OS. <see cref="R2RUtil.NeedsStripping(PEReader)"/> must return
+    /// <see langword="true"/> for such assemblies.
+    /// </summary>
+    [UnixFact]
+    public void NeedsStrippingReturnsTrueForCrossOsR2R()
+    {
+        using var reader = CompilerLogReader.Create(
+            Fixture.Console.Value.CompilerLogPath,
+            BasicAnalyzerKind.None);
+        var analyzerDataList = reader.ReadAllAnalyzerData(0);
+
+        // Find R2R analyzers with a standard architecture machine value (e.g. Amd64).
+        // These are Windows R2R images that need stripping on non-Windows hosts.
+        var windowsR2rData = analyzerDataList
+            .Where(a =>
+            {
+                var bytes = reader.GetAssemblyBytes(a.Mvid);
+                if (!R2RUtil.IsReadyToRun(bytes))
+                {
+                    return false;
+                }
+
+                using var stream = bytes.AsSimpleMemoryStream(writable: false);
+                using var peReader = new PEReader(stream);
+                var machine = peReader.PEHeaders.CoffHeader.Machine;
+                return machine == Machine.Amd64 || machine == Machine.Arm64;
+            })
+            .ToList();
+
+        foreach (var data in windowsR2rData)
+        {
+            var bytes = reader.GetAssemblyBytes(data.Mvid);
+            Assert.True(R2RUtil.NeedsStripping(bytes), $"Windows R2R analyzer {data.FilePath} should need stripping on non-Windows");
+        }
+    }
+
+    /// <summary>
     /// Builds a minimal PE assembly with static fields that have RVAs for each primitive type
     /// exercised by <c>GetMappedFieldDataSize</c>, strips it through <see cref="R2RUtil.StripReadyToRun"/>,
     /// and verifies the output has valid metadata with the same field definitions.

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -391,8 +391,8 @@ public sealed partial class ExportUtil
             foreach (var analyzer in Reader.ReadAllAnalyzerData(compilerCall))
             {
                 var filePath = builder.AnalyzerDirectory.GetNewFilePath(analyzer.FilePath);
-                using var analyzerStream = Reader.GetAssemblyStream(analyzer.Mvid);
-                analyzerStream.WriteTo(filePath);
+                using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+                Reader.CopyAnalyzerBytes(analyzer, fileStream);
                 var arg = $@"/analyzer:""{FormatPathArgument(filePath)}""";
                 list.Add(arg);
             }

--- a/src/Basic.CompilerLog.Util/R2RUtil.cs
+++ b/src/Basic.CompilerLog.Util/R2RUtil.cs
@@ -61,6 +61,16 @@ internal static class R2RUtil
         }
 
         var machine = peReader.PEHeaders.CoffHeader.Machine;
+
+        // On non-Windows, crossgen2 writes an OS-specific sentinel value into the COFF Machine
+        // field (e.g. 0xFD1D on Linux). A standard architecture value (Amd64, Arm64, etc.) in
+        // an R2R image on a non-Windows host therefore indicates a Windows R2R image whose native
+        // code cannot be executed here.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsCurrentOsNativeR2R(machine))
+        {
+            return true;
+        }
+
         return !IsCurrentArchitecture(machine);
     }
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
-    <PackageVersion Include="MessagePack" Version="3.1.4" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(_RuntimeVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The export command was writing raw R2R analyzer bytes without stripping native code, causing BadImageFormatException when loading Windows R2R assemblies on Linux/macOS. Two fixes:

1. ExportUtil.WriteAnalyzers now uses CopyAnalyzerBytes which routes through AnalyzerNormalizationUtil for R2R stripping.

2. R2RUtil.NeedsStripping now detects cross-OS R2R: on non-Windows hosts, a standard Machine.Amd64/Arm64 value in an R2R image indicates a Windows R2R image whose native code cannot execute on the current OS.

3. Added --strip=auto|always|never option to the export command.