### PR TITLE
Fix race condition in temp directory lock system

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CommonUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CommonUtilTests.cs
@@ -40,23 +40,18 @@ public sealed class CommonUtilTests
     }
 
     [Fact]
-    public void GetCompilerLogTempDirectoryCustom()
-    {
-        var custom = @"/custom/base";
-        var dir = CommonUtil.GetCompilerLogTempDirectory(custom);
-        Assert.Equal(Path.Combine(custom, "Basic.CompilerLog"), dir);
-    }
-
-    [Fact]
     public void CleanupDeletesStaleDirectories()
     {
         var parentDir = Path.Combine(Path.GetTempPath(), "Basic.CompilerLog.Test.Cleanup", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(parentDir);
-        var staleDir = Path.Combine(parentDir, Guid.NewGuid().ToString("N"));
+        var dirName = Guid.NewGuid().ToString("N");
+        var staleDir = Path.Combine(parentDir, dirName);
         Directory.CreateDirectory(staleDir);
 
-        // Create a lock file that is NOT held open (simulates a dead process)
-        File.WriteAllText(Path.Combine(staleDir, ".lock"), "");
+        // Create an unlocked lock file in the locks directory (simulates a dead process)
+        var locksDir = Path.Combine(parentDir, "locks");
+        Directory.CreateDirectory(locksDir);
+        File.WriteAllText(Path.Combine(locksDir, dirName + ".lock"), "");
         // Also create a file that would normally exist in a working directory
         File.WriteAllText(Path.Combine(staleDir, "analyzer.dll"), "fake");
 
@@ -84,10 +79,54 @@ public sealed class CommonUtilTests
     {
         var parentDir = Path.Combine(Path.GetTempPath(), "Basic.CompilerLog.Test.Cleanup", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(parentDir);
+        var dirName = Guid.NewGuid().ToString("N");
+        var activeDir = Path.Combine(parentDir, dirName);
+        Directory.CreateDirectory(activeDir);
+
+        // Hold the lock file open in the locks directory to simulate an active process
+        var locksDir = Path.Combine(parentDir, "locks");
+        Directory.CreateDirectory(locksDir);
+        using var lockStream = new FileStream(
+            Path.Combine(locksDir, dirName + ".lock"),
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None);
+
+        CommonUtil.CleanupStaleTempDirectories(parentDir);
+
+        Assert.True(Directory.Exists(activeDir));
+
+        // Cleanup
+        lockStream.Dispose();
+        Directory.Delete(parentDir, recursive: true);
+    }
+
+    [Fact]
+    public void CleanupDeletesLegacyLockedDirectory()
+    {
+        // Tests backward compat: a directory with an in-directory .lock file (old format)
+        // that is not held should be cleaned up
+        var parentDir = Path.Combine(Path.GetTempPath(), "Basic.CompilerLog.Test.Cleanup", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(parentDir);
+        var staleDir = Path.Combine(parentDir, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(staleDir);
+        File.WriteAllText(Path.Combine(staleDir, ".lock"), "");
+
+        CommonUtil.CleanupStaleTempDirectories(parentDir);
+
+        Assert.False(Directory.Exists(staleDir));
+    }
+
+    [Fact]
+    public void CleanupSkipsLegacyLockedDirectory()
+    {
+        // Tests backward compat: a directory with a held in-directory .lock file (old format)
+        // should be skipped
+        var parentDir = Path.Combine(Path.GetTempPath(), "Basic.CompilerLog.Test.Cleanup", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(parentDir);
         var activeDir = Path.Combine(parentDir, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(activeDir);
 
-        // Hold the lock file open to simulate an active process
         using var lockStream = new FileStream(
             Path.Combine(activeDir, ".lock"),
             FileMode.Create,
@@ -98,7 +137,6 @@ public sealed class CommonUtilTests
 
         Assert.True(Directory.Exists(activeDir));
 
-        // Cleanup
         lockStream.Dispose();
         Directory.Delete(parentDir, recursive: true);
     }

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -694,10 +694,10 @@ public sealed class ExportUtilTests : TestBase
         TestOutputHelper.WriteLine(solutionContent);
 
         // Verify complete solution content with both target frameworks
-        var expectedSolution = """
+        var expectedSolution = $"""
             <Solution>
               <Project Path="classlibmulti-net6.0/classlibmulti-net6.0.csproj" />
-              <Project Path="classlibmulti-net9.0/classlibmulti-net9.0.csproj" />
+              <Project Path="classlibmulti-{TestUtil.TestTargetFramework}/classlibmulti-{TestUtil.TestTargetFramework}.csproj" />
             </Solution>
             """;
         Assert.Equal(expectedSolution, solutionContent.Trim());
@@ -783,12 +783,12 @@ public sealed class ExportUtilTests : TestBase
         var exportUtil = new ExportUtil(reader, ExportOptions.ExcludeAnalyzers);
 
         using var tempDir = new TempDir();
-        exportUtil.ExportSolution(tempDir.DirectoryPath, cc => cc.TargetFramework == "net9.0");
+        exportUtil.ExportSolution(tempDir.DirectoryPath, cc => cc.TargetFramework == TestUtil.TestTargetFramework);
 
         var solutionContent = File.ReadAllText(Path.Combine(tempDir.DirectoryPath, "export.slnx"));
-        var expectedSolution = """
+        var expectedSolution = $"""
             <Solution>
-              <Project Path="classlibmulti-net9.0/classlibmulti-net9.0.csproj" />
+              <Project Path="classlibmulti-{TestUtil.TestTargetFramework}/classlibmulti-{TestUtil.TestTargetFramework}.csproj" />
             </Solution>
             """;
         Assert.Equal(expectedSolution, solutionContent.Trim());

--- a/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/LogReaderStateTests.cs
@@ -65,7 +65,8 @@ public class LogReaderStateTests : TestBase
     {
         // Lock files are only created when using the default temp directory (baseDir: null)
         using var state = new Util.LogReaderState();
-        var lockPath = Path.Combine(state.BaseDirectory, ".lock");
+        var dirName = Path.GetFileName(state.BaseDirectory);
+        var lockPath = Path.Combine(CommonUtil.GetLocksDirectory(), dirName + ".lock");
         Assert.True(File.Exists(lockPath));
 
         // Lock should prevent external exclusive access
@@ -89,7 +90,8 @@ public class LogReaderStateTests : TestBase
     public void NoLockFileWithCustomBaseDir()
     {
         var state = new Util.LogReaderState(baseDir: Root.NewDirectory());
-        var lockPath = Path.Combine(state.BaseDirectory, ".lock");
+        var dirName = Path.GetFileName(state.BaseDirectory);
+        var lockPath = Path.Combine(CommonUtil.GetLocksDirectory(), dirName + ".lock");
         Assert.False(File.Exists(lockPath));
         state.Dispose();
     }
@@ -98,7 +100,8 @@ public class LogReaderStateTests : TestBase
     public void DisposeCleansUpLockFile()
     {
         var state = new Util.LogReaderState();
-        var lockPath = Path.Combine(state.BaseDirectory, ".lock");
+        var dirName = Path.GetFileName(state.BaseDirectory);
+        var lockPath = Path.Combine(CommonUtil.GetLocksDirectory(), dirName + ".lock");
         Assert.True(File.Exists(lockPath));
         state.Dispose();
         Assert.False(File.Exists(lockPath));
@@ -122,12 +125,15 @@ public class LogReaderStateTests : TestBase
     [Fact]
     public void CleanupDeletesStaleSiblingWithUnlockedLockFile()
     {
-        // Create a stale directory with an unlocked .lock file (simulates crashed process)
+        // Create a stale directory with an unlocked lock file in the locks dir (simulates crashed process)
         var parentDir = CommonUtil.GetCompilerLogTempDirectory();
         Directory.CreateDirectory(parentDir);
-        var staleDir = Path.Combine(parentDir, Guid.NewGuid().ToString("N"));
+        var dirName = Guid.NewGuid().ToString("N");
+        var staleDir = Path.Combine(parentDir, dirName);
         Directory.CreateDirectory(staleDir);
-        File.WriteAllText(Path.Combine(staleDir, ".lock"), "");
+        var locksDir = CommonUtil.GetLocksDirectory();
+        Directory.CreateDirectory(locksDir);
+        File.WriteAllText(Path.Combine(locksDir, dirName + ".lock"), "");
 
         // Creating a new state should clean up the stale sibling
         using var state = new Util.LogReaderState();

--- a/src/Basic.CompilerLog.UnitTests/TestUtil.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestUtil.cs
@@ -28,7 +28,7 @@ internal static class TestUtil
     /// <summary>
     /// This is the standard target framework that test projects are built against.
     /// </summary>
-    internal const string TestTargetFramework = "net9.0";
+    internal const string TestTargetFramework = "net10.0";
 
     internal static bool IsNetFramework =>
 #if NETFRAMEWORK

--- a/src/Basic.CompilerLog.Util/CommonUtil.cs
+++ b/src/Basic.CompilerLog.Util/CommonUtil.cs
@@ -22,11 +22,16 @@ internal static class CommonUtil
     internal static readonly MessagePackSerializerOptions SerializerOptions = MessagePackSerializerOptions.Standard.WithAllowAssemblyVersionMismatch(true);
 
     /// <summary>
-    /// Gets the parent directory used for compiler log temp working directories. When
-    /// <paramref name="basePath"/> is <c>null</c>, uses <see cref="Path.GetTempPath"/>.
+    /// Gets the parent directory used for compiler log temp working directories.
     /// </summary>
-    internal static string GetCompilerLogTempDirectory(string? basePath = null) =>
-        Path.Combine(basePath ?? Path.GetTempPath(), "Basic.CompilerLog");
+    internal static string GetCompilerLogTempDirectory() =>
+        Path.Combine(Path.GetTempPath(), "Basic.CompilerLog");
+
+    /// <summary>
+    /// Gets the locks directory inside the compiler log temp directory.
+    /// </summary>
+    internal static string GetLocksDirectory() =>
+        Path.Combine(GetCompilerLogTempDirectory(), "locks");
 
     internal static string GetCompilerEntryName(int index) => $"compilations/{index}.txt";
     internal static string GetAssemblyEntryName(Guid mvid) => $"assembly/{mvid:N}";
@@ -77,8 +82,9 @@ internal static class CommonUtil
 
     /// <summary>
     /// Enumerates <paramref name="parentDirectory"/> for subdirectories that are no longer owned by
-    /// a running process and deletes them. Ownership is determined by a <c>.lock</c> file held open
-    /// with <see cref="FileShare.None"/> by the owning <see cref="LogReaderState"/>.
+    /// a running process and deletes them. Ownership is determined by a lock file in the sibling
+    /// <c>locks/</c> directory held open with <see cref="FileShare.None"/> by the owning
+    /// <see cref="LogReaderState"/>.
     /// </summary>
     internal static void CleanupStaleTempDirectories(string parentDirectory)
     {
@@ -87,20 +93,44 @@ internal static class CommonUtil
             return;
         }
 
+        var locksDirectory = Path.Combine(parentDirectory, "locks");
+
         foreach (var dir in Directory.EnumerateDirectories(parentDirectory))
         {
+            // Skip the locks directory itself
+            if (Path.GetFileName(dir) == "locks")
+            {
+                continue;
+            }
+
             try
             {
-                var lockFilePath = Path.Combine(dir, ".lock");
+                var dirName = Path.GetFileName(dir);
+                var lockFilePath = Path.Combine(locksDirectory, dirName + ".lock");
+
                 if (File.Exists(lockFilePath))
                 {
                     // Attempt to open the lock file exclusively. If it succeeds the owning process
                     // is no longer running and the directory is stale.
                     using var fs = new FileStream(lockFilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
                     fs.Dispose();
+
+                    // Lock acquired — owning process is gone. Delete the lock file and directory.
+                    File.Delete(lockFilePath);
+                }
+                else
+                {
+                    // No lock file means either old format or orphaned. Check for a legacy
+                    // in-directory .lock file for backward compat.
+                    var legacyLockPath = Path.Combine(dir, ".lock");
+                    if (File.Exists(legacyLockPath))
+                    {
+                        using var fs = new FileStream(legacyLockPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                        fs.Dispose();
+                    }
                 }
 
-                // Either no lock file (old format) or we successfully acquired the lock (stale).
+                // Either no lock file, acquired the external lock, or acquired legacy lock.
                 // Delete the directory.
                 Directory.Delete(dir, recursive: true);
             }
@@ -110,7 +140,8 @@ internal static class CommonUtil
             }
         }
 
-        // Try to clean up the parent if it's now empty
+        // Try to clean up the locks dir if empty, then the parent
+        DeleteDirectoryIfEmpty(locksDirectory);
         DeleteDirectoryIfEmpty(parentDirectory);
     }
 }

--- a/src/Basic.CompilerLog.Util/LogReaderState.cs
+++ b/src/Basic.CompilerLog.Util/LogReaderState.cs
@@ -93,7 +93,8 @@ public sealed class LogReaderState : IDisposable
     /// <param name="stripReadyToRun">See <see cref="StripReadyToRun"/></param>
     public LogReaderState(string? baseDir = null, bool cacheAnalyzers = true, bool? stripReadyToRun = null)
     {
-        BaseDirectory = baseDir ?? Path.Combine(CommonUtil.GetCompilerLogTempDirectory(), Guid.NewGuid().ToString("N"));
+        var dirName = Guid.NewGuid().ToString("N");
+        BaseDirectory = baseDir ?? Path.Combine(CommonUtil.GetCompilerLogTempDirectory(), dirName);
         CryptoKeyFileDirectory = Path.Combine(BaseDirectory, "CryptoKeys");
         AnalyzerDirectory = Path.Combine(BaseDirectory, "Analyzers");
         StripReadyToRun = stripReadyToRun;
@@ -105,26 +106,36 @@ public sealed class LogReaderState : IDisposable
             _analyzersMap = new();
         }
 
-        _ = Directory.CreateDirectory(BaseDirectory);
-
         // Only create a lock file and run cleanup when using the default shared temp directory.
         // Custom base directories are managed by the caller and don't participate in the
         // lock-based cleanup protocol.
         if (baseDir is null)
         {
+            // Create the lock file FIRST in the shared locks directory. This ensures that
+            // cleanup cannot race with directory creation — the lock is held before the
+            // working directory exists.
+            var locksDir = CommonUtil.GetLocksDirectory();
+            Directory.CreateDirectory(locksDir);
             _lockFileStream = new FileStream(
-                Path.Combine(BaseDirectory, ".lock"),
+                Path.Combine(locksDir, dirName + ".lock"),
                 FileMode.Create,
                 FileAccess.Write,
                 FileShare.None);
 
-            // Now that our lock is held, clean up stale sibling directories from previous
-            // invocations that didn't get a chance to clean up (e.g. process crash).
+            // Now create the working directory
+            Directory.CreateDirectory(BaseDirectory);
+
+            // Clean up stale sibling directories from previous invocations that didn't
+            // get a chance to clean up (e.g. process crash).
             var parentDir = Path.GetDirectoryName(BaseDirectory);
             if (parentDir is not null)
             {
                 CommonUtil.CleanupStaleTempDirectories(parentDir);
             }
+        }
+        else
+        {
+            Directory.CreateDirectory(BaseDirectory);
         }
     }
 
@@ -150,22 +161,6 @@ public sealed class LogReaderState : IDisposable
         // an AssemblyLoadContext
         _analyzersMap?.Clear();
 
-        // Release the lock file before attempting to delete the directory
-        if (_lockFileStream is not null)
-        {
-            var lockFilePath = _lockFileStream.Name;
-            _lockFileStream.Dispose();
-            _lockFileStream = null;
-            try
-            {
-                File.Delete(lockFilePath);
-            }
-            catch (Exception ex)
-            {
-                Debug.Fail(ex.Message);
-            }
-        }
-
         try
         {
             if (Directory.Exists(CryptoKeyFileDirectory))
@@ -185,6 +180,30 @@ public sealed class LogReaderState : IDisposable
         {
             // Nothing to do if we can't delete the directories
             Debug.Fail(ex.Message);
+        }
+
+        // Release the lock file AFTER cleaning up the base directory. The lock must be
+        // held until we're done with the directory so cleanup won't race with us.
+        if (_lockFileStream is not null)
+        {
+            var lockFilePath = _lockFileStream.Name;
+            _lockFileStream.Dispose();
+            _lockFileStream = null;
+            try
+            {
+                File.Delete(lockFilePath);
+            }
+            catch (Exception ex)
+            {
+                Debug.Fail(ex.Message);
+            }
+
+            // Try to clean up the locks directory if it's now empty
+            var locksDir = Path.GetDirectoryName(lockFilePath);
+            if (locksDir is not null)
+            {
+                CommonUtil.DeleteDirectoryIfEmpty(locksDir);
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

The existing `.lock` file system has a race condition when multiple `complog` instances run in parallel. The sequence was: create the temp directory, then create `.lock` inside it. If cleanup runs between those two steps, it sees a directory with no lock file and deletes it -- breaking the active instance.

## Approach

Move lock files into a shared `locks/` subdirectory and create them **before** the working directory:

```
Basic.CompilerLog/
  locks/<guid>.lock   <- created first, held with FileShare.None
  <guid>/             <- created second (the working directory)
```

This eliminates the race window entirely -- by the time the working directory exists, the lock is already held. Cleanup now checks `locks/<name>.lock` for each sibling directory instead of looking inside the directory itself.

Key design decisions:
- Lock release in `Dispose` is deferred until after base directory cleanup, so the lock protects the directory for its full lifetime.
- Legacy in-directory `.lock` files are still recognized by cleanup for backward compatibility with directories created by older versions.
- Removed the unused `basePath` parameter from `GetCompilerLogTempDirectory` to simplify the API.

## Other changes

- Updated `TestTargetFramework` from `net9.0` to `net10.0` to match the SDK version (`10.0.100`), fixing a pre-existing fixture failure when only the .NET 10 SDK is installed.