### PR TITLE
Reset EmitToMemory stream positions

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
@@ -37,8 +37,8 @@ public sealed class CodeAnalysisExtensionsTests : TestBase
         AssertEx.HasData(result.XmlStream);
         AssertEx.HasData(result.MetadataStream);
         Assert.Equal(0, result.AssemblyStream.Position);
-        Assert.Equal(0, result.PdbStream.Position);
-        Assert.Equal(0, result.XmlStream.Position);
-        Assert.Equal(0, result.MetadataStream.Position);
+        Assert.Equal(0, result.PdbStream!.Position);
+        Assert.Equal(0, result.XmlStream!.Position);
+        Assert.Equal(0, result.MetadataStream!.Position);
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CodeAnalysisExtensionTests.cs
@@ -23,15 +23,22 @@ public sealed class CodeAnalysisExtensionsTests : TestBase
         var result = compilation.EmitToMemory(EmitFlags.Default, cancellationToken: CancellationToken);
         AssertEx.Success(TestOutputHelper, result);
         AssertEx.HasData(result.AssemblyStream);
+        Assert.Equal(0, result.AssemblyStream.Position);
         Assert.Null(result.PdbStream);
         Assert.Null(result.XmlStream);
         Assert.Null(result.MetadataStream);
 
-        result = compilation.EmitToMemory(EmitFlags.IncludePdbStream, cancellationToken: CancellationToken);
+        result = compilation.EmitToMemory(
+            EmitFlags.IncludePdbStream | EmitFlags.IncludeXmlStream | EmitFlags.IncludeMetadataStream,
+            cancellationToken: CancellationToken);
         AssertEx.Success(TestOutputHelper, result);
         AssertEx.HasData(result.AssemblyStream);
         AssertEx.HasData(result.PdbStream);
-        Assert.Null(result.XmlStream);
-        Assert.Null(result.MetadataStream);
+        AssertEx.HasData(result.XmlStream);
+        AssertEx.HasData(result.MetadataStream);
+        Assert.Equal(0, result.AssemblyStream.Position);
+        Assert.Equal(0, result.PdbStream.Position);
+        Assert.Equal(0, result.XmlStream.Position);
+        Assert.Equal(0, result.MetadataStream.Position);
     }
 }

--- a/src/Basic.CompilerLog.Util/CodeAnalysisExtensions.cs
+++ b/src/Basic.CompilerLog.Util/CodeAnalysisExtensions.cs
@@ -18,6 +18,11 @@ public static class CodeAnalysisExtensions
             return emitOptions.WithEmitMetadataOnly(true);
         }
 
+        if ((emitFlags & EmitFlags.IncludeMetadataStream) != 0)
+        {
+            return emitOptions.WithIncludePrivateMembers(false);
+        }
+
         return emitOptions;
     }
 

--- a/src/Basic.CompilerLog.Util/CodeAnalysisExtensions.cs
+++ b/src/Basic.CompilerLog.Util/CodeAnalysisExtensions.cs
@@ -67,6 +67,23 @@ public static class CodeAnalysisExtensions
             embeddedTexts,
             metadataPEStream: metadataStream,
             cancellationToken: cancellationToken);
+
+        assemblyStream.Position = 0;
+        if (pdbStream is not null)
+        {
+            pdbStream.Position = 0;
+        }
+
+        if (xmlStream is not null)
+        {
+            xmlStream.Position = 0;
+        }
+
+        if (metadataStream is not null)
+        {
+            metadataStream.Position = 0;
+        }
+
         return new EmitMemoryResult(
             result.Success,
             assemblyStream,


### PR DESCRIPTION
`EmitToMemory` returned streams positioned at the end after Roslyn emitted their contents, requiring consumers to rewind them before reading.

Reset the assembly, PDB, XML, and metadata streams to position 0 before returning the result. Extend the unit test to verify every requested output stream is readable from the beginning.