### PR TITLE
Isolate child dotnet commands from unsafe MSBuild state

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogAppTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogAppTests.cs
@@ -934,7 +934,7 @@ public sealed class CompilerLogAppTests : TestBase, IClassFixture<CompilerLogApp
             var solutionFile = Path.Combine(exportDir.DirectoryPath, "export.slnx");
             Assert.True(File.Exists(solutionFile));
 
-            var result = ProcessUtil.Run("dotnet", $"build \"{solutionFile}\"");
+            var result = DotnetUtil.Command($"build \"{solutionFile}\"", exportDir.DirectoryPath);
             TestOutputHelper.WriteLine(result.StandardOut);
             TestOutputHelper.WriteLine(result.StandardError);
             Assert.True(result.Succeeded, $"Build failed: {result.StandardOut}");

--- a/src/Basic.CompilerLog.UnitTests/DotnetUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/DotnetUtilTests.cs
@@ -15,6 +15,7 @@ public sealed class DotnetUtilTests
             ["MSBuildExtensionsPath32"] = "machine-extensions",
             ["MSBuildExtensionsPath64"] = "machine-extensions-64",
             ["MSBuildLoadMicrosoftTargetsReadOnly"] = "true",
+            ["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "1",
             ["DOTNET_HOST_PATH"] = "dotnet",
         };
 
@@ -22,6 +23,7 @@ public sealed class DotnetUtilTests
 
         Assert.False(childEnvironment.ContainsKey("MSBuildExtensionsPath"));
         Assert.False(childEnvironment.ContainsKey("msbuildsdkspath"));
+        Assert.False(childEnvironment.ContainsKey("MSBUILDENSURESTDOUTFORTASKPROCESSES"));
         Assert.Equal(4, childEnvironment.Count);
         Assert.Equal("machine-extensions", childEnvironment["MSBuildExtensionsPath32"]);
         Assert.Equal("machine-extensions-64", childEnvironment["MSBuildExtensionsPath64"]);

--- a/src/Basic.CompilerLog.UnitTests/DotnetUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/DotnetUtilTests.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using Xunit;
+
+namespace Basic.CompilerLog.UnitTests;
+
+public sealed class DotnetUtilTests
+{
+    [Fact]
+    public void CreateDotnetEnvironmentVariables_ParentSdkPaths_Removed()
+    {
+        var environmentVariables = new Hashtable
+        {
+            ["MSBuildExtensionsPath"] = "parent-extensions",
+            ["msbuildsdkspath"] = "parent-sdks",
+            ["MSBuildExtensionsPath32"] = "machine-extensions",
+            ["MSBuildExtensionsPath64"] = "machine-extensions-64",
+            ["MSBuildLoadMicrosoftTargetsReadOnly"] = "true",
+            ["DOTNET_HOST_PATH"] = "dotnet",
+        };
+
+        var childEnvironment = DotnetUtil.CreateDotnetEnvironmentVariables(environmentVariables);
+
+        Assert.False(childEnvironment.ContainsKey("MSBuildExtensionsPath"));
+        Assert.False(childEnvironment.ContainsKey("msbuildsdkspath"));
+        Assert.Equal(4, childEnvironment.Count);
+        Assert.Equal("machine-extensions", childEnvironment["MSBuildExtensionsPath32"]);
+        Assert.Equal("machine-extensions-64", childEnvironment["MSBuildExtensionsPath64"]);
+        Assert.Equal("true", childEnvironment["MSBuildLoadMicrosoftTargetsReadOnly"]);
+        Assert.Equal("dotnet", childEnvironment["DOTNET_HOST_PATH"]);
+    }
+
+    [UnixFact]
+    public void CreateDotnetEnvironmentVariables_CaseDistinctVariables_Preserved()
+    {
+        var environmentVariables = new Hashtable
+        {
+            ["Path"] = "mixed-case",
+            ["PATH"] = "upper-case",
+        };
+
+        var childEnvironment = DotnetUtil.CreateDotnetEnvironmentVariables(environmentVariables);
+
+        Assert.Equal(2, childEnvironment.Count);
+        Assert.Equal("mixed-case", childEnvironment["Path"]);
+        Assert.Equal("upper-case", childEnvironment["PATH"]);
+    }
+}

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -155,7 +155,7 @@ public sealed class ExportUtilTests : TestBase
         var solutionFile = Path.Combine(tempDir.DirectoryPath, "export.slnx");
         Assert.True(File.Exists(solutionFile));
 
-        var result = ProcessUtil.Run("dotnet", $"build \"{solutionFile}\"");
+        var result = DotnetUtil.Command($"build \"{solutionFile}\"", tempDir.DirectoryPath);
         verifyBuildResult?.Invoke(result);
         testOutputHelper.WriteLine(result.StandardOut);
         testOutputHelper.WriteLine(result.StandardError);

--- a/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/UsingAllCompilerLogTests.cs
@@ -309,7 +309,7 @@ public sealed class UsingAllCompilerLogTests : TestBase
 
         // Build the solution
         TestOutputHelper.WriteLine($"Building solution for {logDataName}");
-        var result = ProcessUtil.Run("dotnet", $"build \"{solutionFile}\"");
+        var result = DotnetUtil.Command($"build \"{solutionFile}\"", tempDir.DirectoryPath);
         TestOutputHelper.WriteLine(result.StandardOut);
         TestOutputHelper.WriteLine(result.StandardError);
         Assert.True(result.Succeeded, $"Build failed for {logDataName}: {result.StandardOut}");

--- a/src/Shared/DotnetUtil.cs
+++ b/src/Shared/DotnetUtil.cs
@@ -20,7 +20,7 @@ internal static class DotnetUtil
         CreateDotnetEnvironmentVariables(Environment.GetEnvironmentVariables());
 
     /// <summary>
-    /// Copies the parent environment without the MSBuild paths that identify its selected SDK.
+    /// Copies the parent environment without MSBuild settings that are unsafe for child commands.
     /// </summary>
     /// <param name="environmentVariables">The parent process environment variables.</param>
     internal static Dictionary<string, string> CreateDotnetEnvironmentVariables(IDictionary environmentVariables)
@@ -31,8 +31,12 @@ internal static class DotnetUtil
         // assemblies from the child SDK. Newer task API dependencies made this latent mismatch fail
         // during task loading. DOTNET_HOST_PATH is retained because it identifies the shared muxer.
         // MSBuildExtensionsPath32 and MSBuildExtensionsPath64 are retained because the CLI does not set
-        // them, preserving deliberate user configuration.
+        // them. Other MSBuild settings are retained unless they are known to be unsafe for child commands.
         // https://github.com/jaredpar/complog/pull/73
+        //
+        // MSBUILDENSURESTDOUTFORTASKPROCESSES makes reusable worker nodes inherit the redirected stdout
+        // handle. ProcessUtil synchronously reads stdout to EOF, so those nodes can block it until they exit.
+        // https://github.com/jaredpar/complog/pull/375
         var comparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
@@ -41,7 +45,8 @@ internal static class DotnetUtil
         {
             var key = (string)entry.Key;
             if (!string.Equals(key, "MSBuildExtensionsPath", StringComparison.OrdinalIgnoreCase) &&
-                !string.Equals(key, "MSBuildSDKsPath", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(key, "MSBuildSDKsPath", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(key, "MSBUILDENSURESTDOUTFORTASKPROCESSES", StringComparison.OrdinalIgnoreCase))
             {
                 map[key] = (string)entry.Value!;
             }

--- a/src/Shared/DotnetUtil.cs
+++ b/src/Shared/DotnetUtil.cs
@@ -16,26 +16,37 @@ internal static class DotnetUtil
 {
     private static readonly Lazy<Dictionary<string, string>> s_lazyDotnetEnvironmentVariables = new(CreateDotnetEnvironmentVariables);
 
-    private static Dictionary<string, string> CreateDotnetEnvironmentVariables()
+    private static Dictionary<string, string> CreateDotnetEnvironmentVariables() =>
+        CreateDotnetEnvironmentVariables(Environment.GetEnvironmentVariables());
+
+    /// <summary>
+    /// Copies the parent environment without the MSBuild paths that identify its selected SDK.
+    /// </summary>
+    /// <param name="environmentVariables">The parent process environment variables.</param>
+    internal static Dictionary<string, string> CreateDotnetEnvironmentVariables(IDictionary environmentVariables)
     {
-        // The CLI, particularly when run from dotnet test, will set the MSBuildSDKsPath environment variable
-        // to point to the current SDK. That could be an SDK that is higher than the version that our tests
-        // are executing under. For example `dotnet test` could spawn an 8.0 process but we end up testing
-        // the 7.0.400 SDK. This environment variable though will point to 8.0 and end up causing load 
-        // issues. Clear it out here so that the `dotnet` commands have a fresh context.
-        //
-        // In 10.0.400 there is a new environment variable getting added that blocks sub `dotnet build` processes
-        // from being created. Clear that out as well.
-        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var comparer = StringComparer.OrdinalIgnoreCase;
-        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        // The .NET CLI, particularly under dotnet test, sets these paths to its selected SDK. A child
+        // command can select a different SDK from its working directory and global.json roll-forward
+        // policy, so retaining either path can mix targets and tasks from the parent SDK with MSBuild
+        // assemblies from the child SDK. Newer task API dependencies made this latent mismatch fail
+        // during task loading. DOTNET_HOST_PATH is retained because it identifies the shared muxer.
+        // MSBuildExtensionsPath32 and MSBuildExtensionsPath64 are retained because the CLI does not set
+        // them, preserving deliberate user configuration.
+        // https://github.com/jaredpar/complog/pull/73
+        var comparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var map = new Dictionary<string, string>(comparer);
+        foreach (DictionaryEntry entry in environmentVariables)
         {
             var key = (string)entry.Key;
-            if (!key.StartsWith("MSBuild", StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(key, "MSBuildExtensionsPath", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(key, "MSBuildSDKsPath", StringComparison.OrdinalIgnoreCase))
             {
-                map.Add(key, (string)entry.Value!);
+                map[key] = (string)entry.Value!;
             }
         }
+
         return map;
     }
 


### PR DESCRIPTION
## Summary

- refine #375's blanket `MSBuild*` environment removal to a three-variable denylist
- remove the two SDK-identifying paths that can mix parent targets/tasks with child MSBuild assemblies
- preserve #375's stdout-handle fix by removing `MSBUILDENSURESTDOUTFORTASKPROCESSES`
- preserve platform-specific environment-name semantics and legitimate unrelated MSBuild settings
- route exported-solution builds through the isolated launcher with the export directory as the working directory

## Root cause

The .NET CLI sets `MSBuildExtensionsPath` and `MSBuildSDKsPath` for its selected SDK. A child `dotnet` command can select a different SDK based on its working directory and `global.json` roll-forward policy.

Inheriting those paths can combine targets and `NuGet.Build.Tasks.dll` from the parent SDK with `Microsoft.Build.Framework` from the child SDK. The mismatch became visible when newer NuGet tasks began implementing `IMultiThreadableTask`, producing MSB4062 type-load failures.

`MSBUILDENSURESTDOUTFORTASKPROCESSES` is a separate hazard: reusable MSBuild worker nodes inherit the redirected stdout handle, while `ProcessUtil` synchronously waits for stdout EOF. Removing it preserves the subprocess-hang fix introduced by #375.

The .NET 10.0.400 SDK bundle itself was verified to contain a matching `Microsoft.Build.Framework`; the type-load failure is caused by cross-SDK environment contamination rather than an inconsistent bundle.

## Why an explicit denylist

PR #375 removed every variable beginning with `MSBuild`. This follow-up retains that fix's known unsafe variables while preserving unrelated MSBuild configuration such as `MSBuildLoadMicrosoftTargetsReadOnly` and `MSBuildExtensionsPath32`/`MSBuildExtensionsPath64`.

The denylist is intentionally explicit. Future SDK-injected variables that identify a parent SDK or alter redirected process lifetime should be evaluated and added when necessary.

## Compatibility

This changes only internal process-launch behavior and restores the existing intent that child `dotnet` commands select a coherent SDK context. `DOTNET_HOST_PATH` remains preserved because it identifies the shared muxer.

## Validation

- `dotnet build Basic.CompilerLog.slnx -warnaserror`
- focused net10.0 run covering `SolutionReaderTests.CryptoKeyFile` and every changed solution-build launch path: 22 passed, Unix-only environment-casing test skipped on Windows
- focused net472 regression test