### PR TITLE
Make complog output byte-deterministic

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
 using Basic.CompilerLog.Util;
 using Xunit;
 
@@ -127,5 +129,56 @@ public sealed class CompilerLogBuilderTests : TestBase
             builder.AddFromDisk(compilerCall, arguments);
             Assert.Equal([RoslynUtil.GetDiagnosticMissingCommitHash(compilerCall.CompilerFilePath!)], builder.Diagnostics);
         });
+    }
+
+    /// <summary>
+    /// The same binary log should convert to the same bytes every time, so that storage which
+    /// deduplicates by content sees one blob rather than one per conversion.
+    /// </summary>
+    [Fact]
+    public void ConvertBinaryLogIsByteIdentical()
+    {
+        var hashes = Enumerable
+            .Range(0, 3)
+            .Select(_ => GetHash(CreateComplog()))
+            .Distinct()
+            .ToList();
+        Assert.Single(hashes);
+
+        byte[] CreateComplog()
+        {
+            using var complogStream = new MemoryStream();
+            using var binlogStream = new FileStream(Fixture.SolutionBinaryLogPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Assert.Empty(CompilerLogUtil.ConvertBinaryLog(binlogStream, complogStream));
+            return complogStream.ToArray();
+        }
+
+        static string GetHash(byte[] bytes)
+        {
+            using var sha = SHA256.Create();
+            return BitConverter.ToString(sha.ComputeHash(bytes));
+        }
+    }
+
+    /// <summary>
+    /// Zip entries default their modification time to the moment the entry is created. That is not
+    /// read back anywhere, but it does put a different value in the header in front of every entry,
+    /// so it has to be pinned for <see cref="ConvertBinaryLogIsByteIdentical"/> to hold. Checked
+    /// separately because a zip timestamp only has two second resolution, so three conversions in a
+    /// row can land on the same value by luck.
+    /// </summary>
+    [Fact]
+    public void ZipEntryTimestampsAreFixed()
+    {
+        using var complogStream = new MemoryStream();
+        using (var binlogStream = new FileStream(Fixture.SolutionBinaryLogPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            Assert.Empty(CompilerLogUtil.ConvertBinaryLog(binlogStream, complogStream));
+        }
+
+        complogStream.Position = 0;
+        using var zip = new ZipArchive(complogStream, ZipArchiveMode.Read, leaveOpen: true);
+        Assert.NotEmpty(zip.Entries);
+        Assert.All(zip.Entries, e => Assert.Equal(new DateTime(1980, 1, 1), e.LastWriteTime.DateTime));
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/MessagePackUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/MessagePackUtilTests.cs
@@ -1,0 +1,53 @@
+using Basic.CompilerLog.Util;
+using Basic.CompilerLog.Util.Serialize;
+using MessagePack;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Basic.CompilerLog.UnitTests;
+
+public sealed class MessagePackUtilTests
+{
+    /// <summary>
+    /// Ids deliberately out of order, and with a pair that differs only by case so that an ordinal
+    /// sort is distinguishable from a culture aware one.
+    /// </summary>
+    private static readonly string[] DiagnosticIds =
+    [
+        "CS8321", "CS0219", "IDE0005", "CA1001", "cs1591", "CS1591", "CA2007", "IDE0060", "CS0168", "CA1822"
+    ];
+
+    private static CSharpCompilationOptions CreateOptions() =>
+        new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            specificDiagnosticOptions: DiagnosticIds.Select(x => new KeyValuePair<string, ReportDiagnostic>(x, ReportDiagnostic.Suppress)));
+
+    /// <summary>
+    /// MessagePack writes a dictionary as a map in enumeration order and
+    /// <see cref="System.Collections.Immutable.ImmutableDictionary{TKey, TValue}"/> enumerates in
+    /// hash order, which .NET seeds per process. Serializing one of those puts the same options on
+    /// the wire in a different order in every process that writes a log, so the order is checked
+    /// directly here: repeating a conversion within one process cannot see it.
+    /// </summary>
+    [Fact]
+    public void SpecificDiagnosticOptionsAreOrdinalSorted()
+    {
+        var (pack, _) = MessagePackUtil.CreateCSharpCompilationOptionsPack(CreateOptions());
+        Assert.Equal(
+            DiagnosticIds.OrderBy(x => x, StringComparer.Ordinal),
+            pack.SpecificDiagnosticOptions!.Keys);
+    }
+
+    [Fact]
+    public void SpecificDiagnosticOptionsRoundTrip()
+    {
+        var options = CreateOptions();
+        var (pack, csharpPack) = MessagePackUtil.CreateCSharpCompilationOptionsPack(options);
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var bytes = MessagePackSerializer.Serialize(pack, CommonUtil.SerializerOptions, cancellationToken);
+        var readPack = MessagePackSerializer.Deserialize<CompilationOptionsPack>(bytes, CommonUtil.SerializerOptions, cancellationToken);
+        var readOptions = MessagePackUtil.CreateCSharpCompilationOptions(readPack, csharpPack);
+        Assert.Equal(options.SpecificDiagnosticOptions, readOptions.SpecificDiagnosticOptions);
+    }
+}

--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -43,6 +43,12 @@ internal sealed class CompilerLogBuilder : IDisposable
     private readonly List<(int CompilerCallIndex, bool IsRefAssembly, Guid Mvid)> _compilerCallMvidList = new();
     private readonly DefaultObjectPool<MemoryStream> _memoryStreamPool = new(new MemoryStreamPoolPolicy(), maximumRetained: 5);
 
+    /// <summary>
+    /// The earliest timestamp the zip format can represent. Values before 1980 are rejected by
+    /// <see cref="ZipArchiveEntry.LastWriteTime"/>.
+    /// </summary>
+    private static readonly DateTimeOffset ZipEpoch = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     private int _compilationCount;
     private bool _closed;
 
@@ -59,6 +65,25 @@ internal sealed class CompilerLogBuilder : IDisposable
         MetadataVersion = metadataVersion ?? Metadata.LatestMetadataVersion;
         ZipArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
         Diagnostics = diagnostics;
+    }
+
+    /// <summary>
+    /// Creates a zip entry with a fixed modification time, so that two logs built from the same
+    /// inputs are byte-identical.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ZipArchive.CreateEntry(string, CompressionLevel)"/> defaults the entry's
+    /// modification time to the moment it is created, which makes every log unique even when its
+    /// contents are not. Nothing reads these timestamps — entries are addressed by name, and their
+    /// names are already content-derived — but they defeat storage layers that deduplicate by
+    /// comparing bytes, because the header preceding each entry differs between two logs that hold
+    /// the identical entry. The value is the DOS epoch, the earliest a zip can represent.
+    /// </remarks>
+    private ZipArchiveEntry CreateEntry(string entryName)
+    {
+        var entry = ZipArchive.CreateEntry(entryName, CompressionLevel.Fastest);
+        entry.LastWriteTime = ZipEpoch;
+        return entry;
     }
 
     /// <summary>
@@ -206,7 +231,7 @@ internal sealed class CompilerLogBuilder : IDisposable
     private void AddCore(CompilationInfoPack infoPack)
     {
         var index = _compilationCount;
-        var entry = ZipArchive.CreateEntry(GetCompilerEntryName(index), CompressionLevel.Fastest);
+        var entry = CreateEntry(GetCompilerEntryName(index));
         using (var entryStream = entry.Open())
         {
             MessagePackSerializer.Serialize(entryStream, infoPack, SerializerOptions);
@@ -234,7 +259,7 @@ internal sealed class CompilerLogBuilder : IDisposable
 
         void WriteMetadata()
         {
-            var entry = ZipArchive.CreateEntry(MetadataFileName, CompressionLevel.Fastest);
+            var entry = CreateEntry(MetadataFileName);
             using var writer = Polyfill.NewStreamWriter(entry.Open(), ContentEncoding, leaveOpen: false);
             Metadata.Create(_compilationCount, MetadataVersion).Write(writer);
         }
@@ -256,7 +281,7 @@ internal sealed class CompilerLogBuilder : IDisposable
                     : null,
             };
             var contentHash = WriteContentMessagePack(pack);
-            var entry = ZipArchive.CreateEntry(LogInfoFileName, CompressionLevel.Fastest);
+            var entry = CreateEntry(LogInfoFileName);
             using var writer = Polyfill.NewStreamWriter(entry.Open(), ContentEncoding, leaveOpen: false);
             writer.WriteLine(contentHash);
         }
@@ -435,7 +460,7 @@ internal sealed class CompilerLogBuilder : IDisposable
 
         if (_contentHashMap.Add(hashText))
         {
-            var entry = ZipArchive.CreateEntry(GetContentEntryName(hashText), CompressionLevel.Fastest);
+            var entry = CreateEntry(GetContentEntryName(hashText));
             using var entryStream = entry.Open();
             stream.Position = 0;
             stream.CopyTo(entryStream);
@@ -668,7 +693,7 @@ internal sealed class CompilerLogBuilder : IDisposable
             return info;
         }
 
-        var entry = ZipArchive.CreateEntry(GetAssemblyEntryName(info.Mvid), CompressionLevel.Fastest);
+        var entry = CreateEntry(GetAssemblyEntryName(info.Mvid));
         using var entryStream = entry.Open();
         using var fileStream = RoslynUtil.OpenBuildFileForRead(filePath);
         fileStream.CopyTo(entryStream);
@@ -712,7 +737,7 @@ internal sealed class CompilerLogBuilder : IDisposable
             return mvid;
         }
 
-        var entry = ZipArchive.CreateEntry(GetAssemblyEntryName(mvid), CompressionLevel.Fastest);
+        var entry = CreateEntry(GetAssemblyEntryName(mvid));
         using var entryStream = entry.Open();
         using var fileStream = RoslynUtil.OpenBuildFileForRead(filePath);
         fileStream.CopyTo(entryStream);

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -52,8 +52,17 @@ public class CompilationOptionsPack
     public bool Deterministic { get; set; }
     [Key(16)]
     public MetadataImportOptions MetadataImportOptions { get; set; }
+    /// <summary>
+    /// Sorted so that the serialized bytes depend only on the contents. A hash-ordered dictionary
+    /// enumerates differently in every process, because .NET randomizes string hashing, which would
+    /// make two logs built from identical inputs differ.
+    /// </summary>
+    /// <remarks>
+    /// The MessagePack wire shape is a map for any dictionary type, so logs written by earlier
+    /// versions deserialize unchanged.
+    /// </remarks>
     [Key(17)]
-    public ImmutableDictionary<string, ReportDiagnostic>? SpecificDiagnosticOptions { get; set; }
+    public ImmutableSortedDictionary<string, ReportDiagnostic>? SpecificDiagnosticOptions { get; set; }
     [Key(18)]
     public bool ReportSuppressedDiagnostics { get; set; }
     [Key(19)]

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackUtil.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackUtil.cs
@@ -98,7 +98,9 @@ internal static class MessagePackUtil
             ConcurrentBuild = options.ConcurrentBuild,
             Deterministic = options.Deterministic,
             MetadataImportOptions =  options.MetadataImportOptions,
-            SpecificDiagnosticOptions = options.SpecificDiagnosticOptions,
+            SpecificDiagnosticOptions = ImmutableSortedDictionary.CreateRange(
+                StringComparer.Ordinal,
+                options.SpecificDiagnosticOptions),
             ReportSuppressedDiagnostics = options.ReportSuppressedDiagnostics,
             DebugPlusMode = debugPlusMode,
         };


### PR DESCRIPTION
Ideally the same inputs should produce the same complog, byte for byte, which makes things like deduped storage cheaper. Right now building one twice from the same binlog gives you two different files.

Two causes:

- `ZipArchive.CreateEntry` stamps each entry's `LastWriteTime` with the moment it was created, so the header in front of every entry differs run to run. Nothing reads these (entries are looked up by name), so they're pinned to `1980-01-01`, the earliest a zip can represent.
- `SpecificDiagnosticOptions` was serialized as an `ImmutableDictionary<string, ReportDiagnostic>`, which enumerates in hash order, and .NET randomises string hashing per process. It's an `ImmutableSortedDictionary` with `StringComparer.Ordinal` now, so the bytes only depend on the contents.

MessagePack writes a map for either dictionary type, so logs written by older versions read back unchanged. It does change the type of a public property on `CompilationOptionsPack` though, which is a binary breaking change for anyone using the pack types directly.

Checked with a small project, built once, `complog create` run three times in separate processes: three different SHA-256s before, the same one all three times after.

No test for this yet, happy to add one if you'd like it.
