### PR TITLE
Synthesize default Win32 resources when replaying compilations

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -31,7 +31,7 @@ public sealed class CompilationDataTests : TestBase
             var data = reader.ReadCompilationData(0);
             var emitResult = data.EmitToMemory(cancellationToken: cancellationToken);
             Assert.True(emitResult.Success);
-            emitResult.AssemblyStream.Position = 0;
+            Assert.Equal(0, emitResult.AssemblyStream.Position);
             using var peReader = new System.Reflection.PortableExecutable.PEReader(emitResult.AssemblyStream, System.Reflection.PortableExecutable.PEStreamOptions.LeaveOpen);
             Assert.True(peReader.PEHeaders.PEHeader!.ResourceTableDirectory.Size > 0);
         });

--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -17,6 +17,26 @@ public sealed class CompilationDataTests : TestBase
         Fixture = fixture;
     }
 
+    /// <summary>
+    /// When the original build didn't pass /win32res the compiler synthesizes the version
+    /// resource from the compilation. Replay needs to do the same or the emitted assembly
+    /// has an empty resource table where the original had version information.
+    /// </summary>
+    [Fact]
+    public void EmitToMemoryHasDefaultVersionResource()
+    {
+        RunInContext(Fixture.ClassLib.Value.CompilerLogPath, static (testOutputHelper, filePath, cancellationToken) =>
+        {
+            using var reader = CompilerLogReader.Create(filePath);
+            var data = reader.ReadCompilationData(0);
+            var emitResult = data.EmitToMemory(cancellationToken: cancellationToken);
+            Assert.True(emitResult.Success);
+            emitResult.AssemblyStream.Position = 0;
+            using var peReader = new System.Reflection.PortableExecutable.PEReader(emitResult.AssemblyStream, System.Reflection.PortableExecutable.PEStreamOptions.LeaveOpen);
+            Assert.True(peReader.PEHeaders.PEHeader!.ResourceTableDirectory.Size > 0);
+        });
+    }
+
     [Fact]
     public void EmitToMemoryCombinations()
     {

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -291,7 +291,11 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
                 win32ResourceStream: ReadFileAsMemoryStream(args.Win32ResourceFile),
                 sourceLinkStream: ReadFileAsMemoryStream(args.SourceLink),
                 resources: args.ManifestResources,
-                embeddedTexts: GetEmbeddedTexts());
+                embeddedTexts: GetEmbeddedTexts(),
+                // A missing icon or manifest is not diagnosed here, matching the compiler
+                // which only notices them at emit
+                win32IconStream: File.Exists(args.Win32Icon) ? ReadFileAsMemoryStream(args.Win32Icon) : null,
+                win32ManifestStream: File.Exists(args.Win32Manifest) ? ReadFileAsMemoryStream(args.Win32Manifest) : null);
         }
 
         MemoryStream? ReadFileAsMemoryStream(string? filePath)

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -301,7 +301,7 @@ public abstract class CompilationData
                 peStream,
                 pdbStream,
                 xmlStream,
-                EmitData.Win32ResourceStream,
+                GetWin32Resources(compilation),
                 EmitData.Resources,
                 emitOptions,
                 debugEntryPoint: null,
@@ -333,6 +333,41 @@ public abstract class CompilationData
         }
     }
 
+    /// <summary>
+    /// The Win32 resources to pass to emit. When the original build passed /win32res that
+    /// content is used directly. Otherwise mirror the command line compiler: it synthesizes
+    /// the version resource (plus any /win32icon and /win32manifest content) from the
+    /// compilation rather than emitting no resources at all.
+    /// </summary>
+    private Stream? GetWin32Resources(Compilation compilation)
+    {
+        if (EmitData.Win32ResourceStream is { } win32ResourceStream)
+        {
+            win32ResourceStream.Position = 0;
+            return win32ResourceStream;
+        }
+
+        if (compilation.Options.OutputKind == OutputKind.NetModule)
+        {
+            return null;
+        }
+
+        if (EmitData.Win32ManifestStream is { } manifestStream)
+        {
+            manifestStream.Position = 0;
+        }
+        if (EmitData.Win32IconStream is { } iconStream)
+        {
+            iconStream.Position = 0;
+        }
+
+        return compilation.CreateDefaultWin32Resources(
+            versionResource: true,
+            noManifest: false,
+            manifestContents: EmitData.Win32ManifestStream,
+            iconInIcoFormat: EmitData.Win32IconStream);
+    }
+
     public EmitMemoryResult EmitToMemory(
         EmitFlags? emitFlags = null,
         EmitOptions? emitOptions = null,
@@ -352,7 +387,7 @@ public abstract class CompilationData
 
         return compilation.EmitToMemory(
             emitFlags ?? EmitFlags,
-            win32ResourceStream: EmitData.Win32ResourceStream,
+            win32ResourceStream: GetWin32Resources(compilation),
             manifestResources: EmitData.Resources,
             emitOptions: emitOptions ?? EmitOptions,
             sourceLinkStream: EmitData.SourceLinkStream,

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -450,6 +450,8 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         var emitPdb = dataPack.EmitPdb ?? !emitOptions.EmitMetadataOnly;
 
         MemoryStream? win32ResourceStream = null;
+        MemoryStream? win32IconStream = null;
+        MemoryStream? win32ManifestStream = null;
         MemoryStream? sourceLinkStream = null;
         List<EmbeddedText>? embeddedTexts = null;
         List<AnalyzerConfig>? analyzerConfigs = null;
@@ -501,6 +503,14 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
                 case RawContentKind.Win32Resource:
                     win32ResourceStream = TryGetContentAsStream(contentHash, filePath);
                     break;
+                // A missing icon or manifest is not diagnosed at creation, matching the
+                // compiler which only notices them at emit
+                case RawContentKind.Win32Icon:
+                    win32IconStream = contentHash is not null ? TryGetContentAsStream(contentHash, filePath) : null;
+                    break;
+                case RawContentKind.Win32Manifest:
+                    win32ManifestStream = contentHash is not null ? TryGetContentAsStream(contentHash, filePath) : null;
+                    break;
                 case RawContentKind.Embed:
                 {
                     if (embeddedTexts is null)
@@ -529,8 +539,6 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
                 case RawContentKind.RuleSet:
                 case RawContentKind.RuleSetInclude:
                 case RawContentKind.AppConfig:
-                case RawContentKind.Win32Manifest:
-                case RawContentKind.Win32Icon:
                     break;
                 default:
                     throw new InvalidOperationException();
@@ -544,7 +552,9 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
             win32ResourceStream: win32ResourceStream,
             sourceLinkStream: sourceLinkStream,
             resources: resourceList,
-            embeddedTexts: embeddedTexts);
+            embeddedTexts: embeddedTexts,
+            win32IconStream: win32IconStream,
+            win32ManifestStream: win32ManifestStream);
 
         var basicAnalyzerHost = CreateBasicAnalyzerHost(compilerCall);
         var analyzerConfigSet = analyzerConfigs is null

--- a/src/Basic.CompilerLog.Util/EmitData.cs
+++ b/src/Basic.CompilerLog.Util/EmitData.cs
@@ -18,6 +18,20 @@ public sealed class EmitData
     public string? XmlFilePath { get; }
     public bool EmitPdb { get; }
     public MemoryStream? Win32ResourceStream { get; }
+
+    /// <summary>
+    /// The /win32icon content when the compilation specified one. Used to synthesize the
+    /// default Win32 resources when <see cref="Win32ResourceStream"/> is null, the same way
+    /// the command line compiler does.
+    /// </summary>
+    public MemoryStream? Win32IconStream { get; }
+
+    /// <summary>
+    /// The /win32manifest content when the compilation specified one. See
+    /// <see cref="Win32IconStream"/>.
+    /// </summary>
+    public MemoryStream? Win32ManifestStream { get; }
+
     public MemoryStream? SourceLinkStream { get; }
     public IEnumerable<ResourceDescription>? Resources { get; }
     public IEnumerable<EmbeddedText>? EmbeddedTexts { get; }
@@ -29,12 +43,16 @@ public sealed class EmitData
         MemoryStream? win32ResourceStream,
         MemoryStream? sourceLinkStream,
         IEnumerable<ResourceDescription>? resources,
-        IEnumerable<EmbeddedText>? embeddedTexts)
+        IEnumerable<EmbeddedText>? embeddedTexts,
+        MemoryStream? win32IconStream = null,
+        MemoryStream? win32ManifestStream = null)
     {
         AssemblyFileName = assemblyFileName;
         EmitPdb = emitPdb;
         XmlFilePath = xmlFilePath;
         Win32ResourceStream = win32ResourceStream;
+        Win32IconStream = win32IconStream;
+        Win32ManifestStream = win32ManifestStream;
         SourceLinkStream = sourceLinkStream;
         Resources = resources;
         EmbeddedTexts = embeddedTexts;


### PR DESCRIPTION
Fixes #381

* `CompilationData` now mirrors csc by calling `Compilation.CreateDefaultWin32Resources` when no `/win32res` content was recorded, so replayed assemblies get the version resource the original had
* `CompilerLogReader` exposes the recorded `/win32icon` and `/win32manifest` content through `EmitData` (previously read but unused)
* `BinaryLogReader` passes the icon and manifest streams through as well
* A missing icon/manifest still isn't diagnosed at creation, matching the compiler which only notices them at emit

A couple of notes: the `EmitData` constructor gains two optional parameters (source compatible, binary breaking), and `/nowin32manifest` isn't captured in the log format so an exe built with it will now get a default manifest on replay — happy to plumb that flag through the packs if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
