### PR TITLE
Resolve relative analyzer and reference paths against the base directory

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogBuilderTests.cs
@@ -40,6 +40,28 @@ public sealed class CompilerLogBuilderTests : TestBase
         });
     }
 
+    /// <summary>
+    /// Analyzer and metadata reference paths are not resolved by the command line parser (that
+    /// happens later when the compiler loads them) so a relative path has to be resolved against
+    /// the base directory here, not the process working directory.
+    /// </summary>
+    [Fact]
+    public void AddWithRelativeAnalyzerAndReferencePaths()
+    {
+        WithCompilerCall((builder, compilerCall, _) =>
+        {
+            var projectDirectory = Path.Combine(RootDirectory, "relative");
+            Directory.CreateDirectory(projectDirectory);
+            var fileName = "relative-analyzer.dll";
+            File.Copy(typeof(CompilerLogBuilder).Assembly.Location, Path.Combine(projectDirectory, fileName));
+            compilerCall = new CompilerCall(
+                Path.Combine(projectDirectory, "relative.csproj"),
+                compilerFilePath: compilerCall.CompilerFilePath);
+            builder.AddFromDisk(compilerCall, [$"/analyzer:{fileName}", $"/reference:{fileName}"]);
+            Assert.Empty(builder.Diagnostics);
+        });
+    }
+
     [Fact]
     public void RulesetMissing()
     {

--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -444,6 +444,16 @@ internal sealed class CompilerLogBuilder : IDisposable
         return hashText;
     }
 
+    /// <summary>
+    /// The command line parser does not resolve analyzer or metadata reference paths against the
+    /// base directory, that happens later when the compiler loads them. Do the same here so a
+    /// relative path on the command line isn't resolved against the process working directory.
+    /// </summary>
+    private static string ResolveOnDiskPath(string filePath, CommandLineArguments args) =>
+        !Path.IsPathRooted(filePath) && args.BaseDirectory is { } baseDirectory
+            ? Path.Combine(baseDirectory, filePath)
+            : filePath;
+
     private void AddReferences(CompilationDataPack dataPack, CommandLineArguments args)
     {
         var explicitModuleSet = new HashSet<Guid>();
@@ -451,15 +461,16 @@ internal sealed class CompilerLogBuilder : IDisposable
 
         foreach (var reference in args.MetadataReferences)
         {
+            var referencePath = ResolveOnDiskPath(reference.Reference, args);
             if (reference.Properties.Kind == MetadataImageKind.Assembly)
             {
-                var (mvid, assemblyName, assemblyInformationalVersion, netModuleNames) = AddAssembly(reference.Reference);
+                var (mvid, assemblyName, assemblyInformationalVersion, netModuleNames) = AddAssembly(referencePath);
 
                 var netModuleMvids = ImmutableArray<Guid>.Empty;
                 if (netModuleNames.Length > 0)
                 {
                     var mvidBuilder = ImmutableArray.CreateBuilder<Guid>(netModuleNames.Length);
-                    var assemblyDir = Path.GetDirectoryName(reference.Reference)!;
+                    var assemblyDir = Path.GetDirectoryName(referencePath)!;
                     foreach (var netModuleName in netModuleNames)
                     {
                         var netModulePath = Path.Combine(assemblyDir, netModuleName);
@@ -482,7 +493,7 @@ internal sealed class CompilerLogBuilder : IDisposable
                     Kind = reference.Properties.Kind,
                     EmbedInteropTypes = reference.Properties.EmbedInteropTypes,
                     Aliases = reference.Properties.Aliases,
-                    FilePath = reference.Reference,
+                    FilePath = referencePath,
                     AssemblyName = assemblyName,
                     AssemblyInformationalVersion = assemblyInformationalVersion,
                     NetModuleMvids = netModuleMvids,
@@ -495,13 +506,13 @@ internal sealed class CompilerLogBuilder : IDisposable
                 Debug.Assert(reference.Properties.Aliases.IsEmpty);
                 Debug.Assert(!reference.Properties.EmbedInteropTypes);
 
-                 var mvid = AddNetModule(reference.Reference);
+                 var mvid = AddNetModule(referencePath);
                  var pack = new ReferencePack()
                  {
                      Mvid = mvid,
                      Kind = MetadataImageKind.Module,
                      Aliases = [],
-                     FilePath = reference.Reference,
+                     FilePath = referencePath,
                  };
                  dataPack.References.Add(pack);
                  explicitModuleSet.Add(mvid);
@@ -635,11 +646,12 @@ internal sealed class CompilerLogBuilder : IDisposable
     {
         foreach (var analyzer in args.AnalyzerReferences)
         {
-            var (mvid, assemblyName, assemblyInformationalVersion, _) = AddAssembly(analyzer.FilePath);
+            var analyzerPath = ResolveOnDiskPath(analyzer.FilePath, args);
+            var (mvid, assemblyName, assemblyInformationalVersion, _) = AddAssembly(analyzerPath);
             var pack = new AnalyzerPack()
             {
                 Mvid = mvid,
-                FilePath = analyzer.FilePath,
+                FilePath = analyzerPath,
                 AssemblyName = assemblyName,
                 AssemblyInformationalVersion = assemblyInformationalVersion
             };


### PR DESCRIPTION
The command line parser leaves analyzer and metadata reference paths unresolved (the compiler resolves them at load time), so a relative `/analyzer:` or `/reference:` path reached `AddAssembly` as-is and got opened relative to the process working directory — complog creation fails with a missing file error. I hit this from nuget-to-complog (#287), where the compiler calls are hand-built rather than coming from MSBuild.

This resolves them against `CommandLineArguments.BaseDirectory`, the same way the `Resolve` helper in `AddFromDisk` already does for `/win32res` and friends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
