### PR TITLE
Work around metadata-only PDB emit failures

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilationDataTests.cs
@@ -2,6 +2,7 @@
 using Basic.CompilerLog.Util;
 using Basic.CompilerLog.Util.Impl;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Xunit;
 
@@ -79,6 +80,28 @@ public sealed class CompilationDataTests : TestBase
             Assert.Null(emitResult.PdbStream);
             Assert.Null(emitResult.XmlStream);
             Assert.Null(emitResult.MetadataStream);
+        });
+    }
+
+    /// <summary>
+    /// Covers <see href="https://github.com/dotnet/roslyn/issues/78721"/> while the fix in
+    /// <see href="https://github.com/dotnet/roslyn/pull/85028"/> is not yet available in our Roslyn package.
+    /// </summary>
+    [Fact]
+    public void EmitToMemoryMetadataOnlyWithPdbPath()
+    {
+        RunInContext(Fixture.ClassLib.Value.CompilerLogPath, static (testOutputHelper, filePath, cancellationToken) =>
+        {
+            using var reader = CompilerLogReader.Create(filePath);
+            var data = reader.ReadCompilationData(0);
+            var emitOptions = data.EmitOptions
+                .WithEmitMetadataOnly(true)
+                .WithDebugInformationFormat(DebugInformationFormat.Embedded)
+                .WithPdbFilePath("test.pdb");
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => data.EmitToMemory(EmitFlags.MetadataOnly, emitOptions, cancellationToken));
+            Assert.Equal("metadataPEStream", exception.ParamName);
         });
     }
 

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -374,6 +374,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
         CompilationDataPack dataPack)
     {
         var emitOptions = MessagePackUtil.CreateEmitOptions(GetContentPack<EmitOptionsPack>(pack.EmitOptionsHash));
+        emitOptions = ApplyMetadataOnlyEmitWorkaround(emitOptions);
         ParseOptions parseOptions;
         CompilationOptions compilationOptions;
         if (pack.IsCSharp)
@@ -395,6 +396,25 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
 
         compilationOptions = MaterializeCryptoKeyFile(dataPack, compilationOptions);
         return (emitOptions, parseOptions, compilationOptions);
+
+        EmitOptions ApplyMetadataOnlyEmitWorkaround(EmitOptions emitOptions)
+        {
+            // Metadata-only output cannot have an associated PDB. Current Roslyn can retain the PDB path,
+            // emit a CodeView entry, or reject embedded debug information. Work around dotnet/roslyn#85028
+            // until a Roslyn package containing the fix is available.
+            if (!emitOptions.EmitMetadataOnly)
+            {
+                return emitOptions;
+            }
+
+            emitOptions = emitOptions.WithPdbFilePath(null!);
+            if (emitOptions.DebugInformationFormat == DebugInformationFormat.Embedded)
+            {
+                emitOptions = emitOptions.WithDebugInformationFormat(DebugInformationFormat.PortablePdb);
+            }
+
+            return emitOptions;
+        }
 
         // This method will materialize the crypto key file to the location specified by the path mapping util. This
         // is the rare case where reading compilation information will cause a file to be written to disk. It's the


### PR DESCRIPTION
Metadata-only compilations can retain PDB-specific emit options that current Roslyn mishandles, causing `EmitToMemory` failures or invalid CodeView metadata. Roslyn PR dotnet/roslyn#85028 fixes this upstream, but that fix is not yet available in a package complog can reference.

This temporarily normalizes metadata-only `EmitOptions` while `CompilerLogReader` rehydrates a compilation:

- clears the PDB path because metadata-only output has no associated PDB
- replaces embedded debug information with portable PDB format to avoid the current Roslyn guard
- keeps the workaround local to reader option deserialization so it remains transparent to callers

Adds regression coverage demonstrating the upstream Roslyn failure and links the related issue and fix.

**Testing**

- `dotnet test src\Basic.CompilerLog.UnitTests\Basic.CompilerLog.UnitTests.csproj --framework net10.0 --no-restore --blame-hang --blame-hang-timeout 60s`