### PR TITLE
Remove redundant generated PDB state

### DIFF
--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -395,12 +395,10 @@ internal sealed class CompilerLogBuilder : IDisposable
     {
         if (!RoslynUtil.HasGeneratedFilesInPdb(args))
         {
-            dataPack.HasGeneratedFilesInPdb = false;
             dataPack.IncludesGeneratedText = false;
             return;
         }
 
-        dataPack.HasGeneratedFilesInPdb = true;
         try
         {
             var generatedFiles = RoslynUtil.ReadGeneratedFilesFromPdb(compilerCall, args);

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -792,9 +792,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
             return true;
         }
 
-        return dataPack.HasGeneratedFilesInPdb is true
-            ? dataPack.IncludesGeneratedText
-            : dataPack.IncludesGeneratedText;
+        return dataPack.IncludesGeneratedText;
     }
 
     /// <inheritdoc cref="ICompilerCallReader.ReadAllGeneratedSourceTexts(CompilerCall)"/>

--- a/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
+++ b/src/Basic.CompilerLog.Util/Serialize/MessagePackTypes.cs
@@ -280,6 +280,9 @@ public class CompilationDataPack
     public bool IncludesGeneratedText { get; set; }
     [Key(6)]
     public SourceHashAlgorithm ChecksumAlgorithm { get; set; }
+    /// <summary>
+    /// Deprecated. Retained to preserve the serialized layout.
+    /// </summary>
     [Key(7)]
     public bool? HasGeneratedFilesInPdb { get; set; }
     [Key(8)]


### PR DESCRIPTION
## Summary
- simplify generated-file availability to use `IncludesGeneratedText` directly
- stop writing the unused `HasGeneratedFilesInPdb` serialized field
- retain MessagePack key 7 as a deprecated compatibility placeholder

## Tests
- `CompilerLogBuilderTests` (10 passed)
- `CompilerLogReaderTests.HasAllGeneratedFileContent` (1 passed)