### PR TITLE
Assert compiler log content paths are rooted

### DIFF
--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -290,33 +290,23 @@ internal sealed class CompilerLogBuilder : IDisposable
     private void AddContent(CompilationDataPack dataPack, RawContentKind kind, string filePath, Stream stream)
     {
         var contentHash = WriteContent(stream);
-
-        dataPack.ContentList.Add(((int)kind, new ContentPack()
-        {
-            ContentHash = contentHash,
-            FilePath = filePath
-        }));
+        AddContentCore(dataPack, kind, filePath, contentHash);
     }
 
     private bool AddContentFromDisk(CompilationDataPack dataPack, RawContentKind kind, string filePath)
     {
         var contentHash = WriteContentFromDisk(filePath);
+        AddContentCore(dataPack, kind, filePath, contentHash);
+        return contentHash is not null;
+    }
+
+    private static void AddContentCore(CompilationDataPack dataPack, RawContentKind kind, string filePath, string? contentHash)
+    {
+        Debug.Assert(Path.IsPathRooted(filePath));
 
         dataPack.ContentList.Add(((int)kind, new ContentPack()
         {
             ContentHash = contentHash,
-            FilePath = filePath
-        }));
-
-        return contentHash is not null;
-    }
-
-    private void AddContent(CompilationDataPack dataPack, RawContentKind kind, string filePath, string content)
-    {
-        using var stream = new StringStream(content, ContentEncoding);
-        dataPack.ContentList.Add(((int)kind, new ContentPack()
-        {
-            ContentHash = WriteContent(stream),
             FilePath = filePath
         }));
     }


### PR DESCRIPTION
## Summary
- centralize `ContentPack` creation in `AddContentCore`
- assert that every stored content path is rooted
- remove the unused string-content overload

## Validation
- full net10.0 unit suite: 1,024 passed, 6 skipped
- full solution build across target frameworks