### PR TITLE
Align SolutionReader workspaces with MSBuildWorkspace conventions

### DIFF
--- a/Basic.CompilerLog.slnx
+++ b/Basic.CompilerLog.slnx
@@ -3,5 +3,6 @@
   <Project Path="src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj" />
   <Project Path="src/Basic.CompilerLog.App/Basic.CompilerLog.App.csproj" />
   <Project Path="src/Basic.CompilerLog/Basic.CompilerLog.csproj" />
+  <Project Path="src/Basic.CompilerLog.WorkspaceComparer/Basic.CompilerLog.WorkspaceComparer.csproj" />
   <Project Path="src/Scratch/Scratch.csproj" />
 </Solution>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,6 +19,16 @@ The core library lives in `src/Basic.CompilerLog.Util/`. Key source files:
 CLI logic lives in `src/Basic.CompilerLog.App/` (`CompilerLogApp.cs` handles command dispatch),
 with `src/Basic.CompilerLog/` as the thin `complog` global-tool entry point.
 
+`src/Basic.CompilerLog.WorkspaceComparer/` is a development tool for comparing the workspace loaded
+by `MSBuildWorkspace` with the workspace reconstructed by `SolutionReader`. It reports structural
+differences in projects, documents, project and metadata references, analyzers, and compiler options,
+making it easier to spot where compiler-log workspaces diverge from the shape consumers normally see
+through `MSBuildWorkspace`:
+
+```bash
+dotnet run --project src/Basic.CompilerLog.WorkspaceComparer -- <project-or-solution> <compiler-log>
+```
+
 ## Architecture Notes
 
 - **Multi-targeting**: The Util library targets net9.0/net10.0/net472/netstandard2.0 for broad

--- a/src/Basic.CompilerLog.App/CompilerLogApp.cs
+++ b/src/Basic.CompilerLog.App/CompilerLogApp.cs
@@ -999,16 +999,7 @@ public sealed class CompilerLogApp(
     {
         var compilerCalls = ReadAllCompilerCalls(reader, predicate);
 
-        // Set used to determine if the projects are single or multi-targeted.
-        var isMultiTargetedMap = new Dictionary<string, bool>(PathUtil.Comparer);
-        foreach (var compilerCall in compilerCalls)
-        {
-            if (compilerCall.Kind == CompilerCallKind.Regular)
-            {
-                ref bool isMultiTargeted = ref CollectionsMarshal.GetValueRefOrAddDefault(isMultiTargetedMap, compilerCall.ProjectFilePath, out var exists);
-                isMultiTargeted = exists;
-            }
-        }
+        var multiTargetedProjectFilePaths = reader.GetMultiTargetedProjectFilePaths(predicate);
 
         // Generate unique names for each compiler call
         var hashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1030,7 +1021,7 @@ public sealed class CompilerLogApp(
                 name = newName;
             }
 
-            result.Add(new NamedCompilerCall(name, compilerCall, isMultiTargetedMap.GetValueOrDefault(compilerCall.ProjectFilePath)));
+            result.Add(new NamedCompilerCall(name, compilerCall, multiTargetedProjectFilePaths.Contains(compilerCall.ProjectFilePath)));
         }
 
         return result;
@@ -1040,7 +1031,7 @@ public sealed class CompilerLogApp(
             var name = Path.GetFileNameWithoutExtension(compilerCall.ProjectFileName);
             return compilerCall.Kind switch
             {
-                CompilerCallKind.Regular => string.IsNullOrEmpty(compilerCall.TargetFramework) || !isMultiTargetedMap.GetValueOrDefault(compilerCall.ProjectFilePath)
+                CompilerCallKind.Regular => string.IsNullOrEmpty(compilerCall.TargetFramework) || !multiTargetedProjectFilePaths.Contains(compilerCall.ProjectFilePath)
                     ? name
                     : $"{name}-{compilerCall.TargetFramework}",
                 _ => $"{name}-{compilerCall.Kind.ToString().ToLowerInvariant()}",

--- a/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BinaryLogReaderTests.cs
@@ -252,4 +252,15 @@ public sealed class BinaryLogReaderTests : TestBase
         var data2 = reader.ReadMSBuildData();
         Assert.Same(data1, data2);
     }
+
+    [Fact]
+    public void ReadAllSourceTextDataClassifiesAdditionalFilesAsAdditionalText()
+    {
+        using var reader = BinaryLogReader.Create(Fixture.ConsoleComplex.Value.BinaryLogPath!);
+        var compilerCall = reader.ReadAllCompilerCalls().Single();
+        var sourceTextData = reader.ReadAllSourceTextData(compilerCall)
+            .Single(data => Path.GetFileName(data.FilePath) == "additional.txt");
+
+        Assert.Equal(SourceTextKind.AdditionalText, sourceTextData.SourceTextKind);
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -80,6 +80,11 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
     internal Lazy<LogData> ConsoleWithReference { get; }
 
     /// <summary>
+    /// A console project that has a reference to a multi-targeted library
+    /// </summary>
+    internal Lazy<LogData> ConsoleWithMultiTargetReference { get; }
+
+    /// <summary>
     /// This is a solution that has two projects (library and console) where the console
     /// has a reference to the library using an extern alias.
     /// </summary>
@@ -318,7 +323,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                   </PropertyGroup>
                   <ItemGroup>
                     <EmbeddedResource Include="resource.txt" />
-                    <AdditionalFiles Include="additional.txt" FixtureKey="true" />
+                    <AdditionalFiles Include="Assets\additional.txt" FixtureKey="true" />
                     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="FixtureKey" />
                   </ItemGroup>
                 </Project>
@@ -336,9 +341,17 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                 """, TestBase.DefaultEncoding);
             File.WriteAllText(Path.Combine(scratchPath, "line.txt"), "this is content", TestBase.DefaultEncoding);
 
-            File.WriteAllText(Path.Combine(scratchPath, "additional.txt"), """
+            var assetsPath = Directory.CreateDirectory(Path.Combine(scratchPath, "Assets")).FullName;
+            File.WriteAllText(Path.Combine(assetsPath, "additional.txt"), """
                 This is an additional file.
                 It just has some text in it
+                """, TestBase.DefaultEncoding);
+
+            var featuresPath = Directory.CreateDirectory(Path.Combine(scratchPath, "Features")).FullName;
+            File.WriteAllText(Path.Combine(featuresPath, "Nested.cs"), "class Nested { }", TestBase.DefaultEncoding);
+            File.WriteAllText(Path.Combine(featuresPath, ".editorconfig"), """
+                [*.cs]
+                dotnet_diagnostic.CA1822.severity = none
                 """, TestBase.DefaultEncoding);
 
             // File with a space in the name to make sure we quote correctly in RSP
@@ -481,6 +494,52 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
                 """,
                 TestBase.DefaultEncoding);
             RunDotnetCommand($@"add . reference ""{classLibPath}""", consolePath);
+            RunDotnetCommand($@"sln add ""{consolePath}""", scratchPath);
+
+            RunDotnetCommand("build -bl -nr:false", scratchPath);
+        });
+
+        ConsoleWithMultiTargetReference = WithBuild("console-with-multi-target-project-ref.complog", void (string scratchPath) =>
+        {
+            RunDotnetCommand("new sln -n ConsoleWithMultiTargetProjectRef", scratchPath);
+
+            var classLibPath = Directory.CreateDirectory(Path.Combine(scratchPath, "classlib")).FullName;
+            File.WriteAllText(Path.Combine(classLibPath, "util.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net6.0;{TestUtil.TestTargetFramework}</TargetFrameworks>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """, TestBase.DefaultEncoding);
+            File.WriteAllText(Path.Combine(classLibPath, "Class1.cs"), """
+                namespace Util;
+                public static class NameInfo
+                {
+                    public static string GetName() => "Hello World";
+                }
+                """, TestBase.DefaultEncoding);
+            RunDotnetCommand($@"sln add ""{classLibPath}""", scratchPath);
+
+            var consolePath = Directory.CreateDirectory(Path.Combine(scratchPath, "console")).FullName;
+            File.WriteAllText(Path.Combine(consolePath, "console-with-reference.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{TestUtil.TestTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="..\classlib\util.csproj" />
+                  </ItemGroup>
+                </Project>
+                """, TestBase.DefaultEncoding);
+            File.WriteAllText(Path.Combine(consolePath, "Program.cs"), """
+                using Util;
+                Console.WriteLine(NameInfo.GetName());
+                """, TestBase.DefaultEncoding);
             RunDotnetCommand($@"sln add ""{consolePath}""", scratchPath);
 
             RunDotnetCommand("build -bl -nr:false", scratchPath);
@@ -896,6 +955,7 @@ public sealed class CompilerLogFixture : FixtureBase, IDisposable
         yield return nameof(Console);
         yield return nameof(ConsoleNoGenerator);
         yield return nameof(ConsoleWithReference);
+        yield return nameof(ConsoleWithMultiTargetReference);
         yield return nameof(ConsoleWithAliasReference);
         yield return nameof(ConsoleComplex);
         yield return nameof(ClassLib);

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -2,6 +2,7 @@
 using Basic.CompilerLog.Util.Impl;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,6 +45,9 @@ public sealed class SolutionReaderTests : TestBase
         return solution;
     }
 
+    private static string GetLogFilePath(LogData logData, bool useBinaryLog) =>
+        useBinaryLog ? logData.BinaryLogPath! : logData.CompilerLogPath;
+
     [Theory]
     [MemberData(nameof(GetSimpleBasicAnalyzerKinds))]
     public async Task DocumentsGeneratedDefaultHost(BasicAnalyzerKind basicAnalyzerKind)
@@ -85,12 +89,13 @@ public sealed class SolutionReaderTests : TestBase
         {
             var solution = GetSolution(filePath, BasicAnalyzerKind.None);
             var consoleProject = solution.Projects
-                .Where(x => x.Name == "console-with-reference.csproj")
+                .Where(x => Path.GetFileName(x.FilePath) == "console-with-reference.csproj")
                 .Single();
+            Assert.Equal("console-with-reference", consoleProject.Name);
             var projectReference = consoleProject.ProjectReferences.Single();
             var utilProject = solution.GetProject(projectReference.ProjectId);
             Assert.NotNull(utilProject);
-            Assert.Equal("util.csproj", utilProject.Name);
+            Assert.Equal("util", utilProject.Name);
             var compilation = await consoleProject.GetCompilationAsync(CancellationToken);
             Assert.NotNull(compilation);
             var result = compilation.EmitToMemory(cancellationToken: CancellationToken);
@@ -123,4 +128,206 @@ public sealed class SolutionReaderTests : TestBase
         var diagnostics = compilation.GetDiagnostics(CancellationToken);
         Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SingleTargetProjectNameUsesProjectFileBaseName(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.Console.Value, useBinaryLog);
+        var project = GetSolution(filePath, BasicAnalyzerKind.None).Projects.Single();
+
+        Assert.Equal("console", project.Name);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MultiTargetProjectNamesIncludeTargetFramework(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ClassLibMulti.Value, useBinaryLog);
+        var projects = GetSolution(filePath, BasicAnalyzerKind.None).Projects
+            .OrderBy(project => project.Name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(
+            [$"classlibmulti ({TestUtil.TestTargetFramework})", "classlibmulti (net6.0)"],
+            projects.Select(project => project.Name));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AssemblyNameExcludesOutputExtension(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ClassLibMulti.Value, useBinaryLog);
+        var projects = GetSolution(filePath, BasicAnalyzerKind.None).Projects.ToList();
+
+        Assert.All(projects, project => Assert.Equal("classlibmulti", project.AssemblyName));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DocumentPropertiesMatchWorkspaceConventions(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ConsoleComplex.Value, useBinaryLog);
+        var project = GetSolution(filePath, BasicAnalyzerKind.None).Projects.Single();
+        var document = project.Documents.Single(document => Path.GetFileName(document.FilePath) == "Nested.cs");
+
+        Assert.Equal("Nested.cs", document.Name);
+        Assert.Equal(["Features"], document.Folders);
+        Assert.True(Path.IsPathRooted(document.FilePath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AdditionalDocumentPropertiesMatchWorkspaceConventions(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ConsoleComplex.Value, useBinaryLog);
+        var project = GetSolution(filePath, BasicAnalyzerKind.None).Projects.Single();
+        var document = Assert.Single(project.AdditionalDocuments);
+
+        Assert.Equal("additional.txt", document.Name);
+        Assert.Equal(["Assets"], document.Folders);
+        Assert.True(Path.IsPathRooted(document.FilePath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnalyzerConfigDocumentPropertiesMatchWorkspaceConventions(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ConsoleComplex.Value, useBinaryLog);
+        var project = GetSolution(filePath, BasicAnalyzerKind.None).Projects.Single();
+        var document = project.AnalyzerConfigDocuments.Single(
+            document => document.FilePath!.EndsWith(
+                Path.Combine("Features", ".editorconfig"),
+                StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(".editorconfig", document.Name);
+        Assert.Equal(["Features"], document.Folders);
+        Assert.True(Path.IsPathRooted(document.FilePath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MetadataReferenceDisplayUsesReferenceFileName(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.Console.Value, useBinaryLog);
+        var reader = SolutionReader.Create(filePath, BasicAnalyzerKind.None);
+        ReaderList.Add(reader);
+        var compilerCall = reader.Reader.ReadAllCompilerCalls().Single();
+        var expectedReference = reader.Reader.ReadAllReferenceData(compilerCall)
+            .First(reference => Path.GetFileName(reference.FilePath) == "System.Runtime.dll");
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddSolution(reader.ReadSolutionInfo()).Projects.Single();
+        var actualReference = project.MetadataReferences.Single(
+            reference => Path.GetFileName(reference.Display) == "System.Runtime.dll");
+
+        var expectedDisplay = useBinaryLog ? expectedReference.FilePath : expectedReference.FileName;
+        Assert.Equal(expectedDisplay, actualReference.Display);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnalyzerReferencePathsPointToExtractedFiles(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.Console.Value, useBinaryLog);
+        var reader = SolutionReader.Create(filePath, BasicAnalyzerKind.OnDisk);
+        ReaderList.Add(reader);
+        var compilerCall = reader.Reader.ReadAllCompilerCalls().Single();
+        var expectedReferenceNames = reader.Reader.ReadAllAnalyzerData(compilerCall)
+            .Select(reference => reference.FileName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddSolution(reader.ReadSolutionInfo()).Projects.Single();
+
+        Assert.NotEmpty(expectedReferenceNames);
+        Assert.Equal(expectedReferenceNames.Count, project.AnalyzerReferences.Count);
+        foreach (var reference in project.AnalyzerReferences)
+        {
+            Assert.Contains(Path.GetFileName(reference.FullPath!), expectedReferenceNames);
+            Assert.Equal(Path.GetFileNameWithoutExtension(reference.FullPath), reference.Display);
+            Assert.True(Path.IsPathRooted(reference.FullPath));
+            Assert.True(File.Exists(reference.FullPath));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OutputFilePathUsesCompilerOutput(bool useBinaryLog)
+    {
+        var logData = Fixture.Console.Value;
+        var filePath = GetLogFilePath(logData, useBinaryLog);
+        var reader = SolutionReader.Create(filePath, BasicAnalyzerKind.None);
+        ReaderList.Add(reader);
+        var compilerCall = reader.Reader.ReadAllCompilerCalls().Single();
+        var compilerCallData = reader.Reader.ReadCompilerCallData(compilerCall);
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddSolution(reader.ReadSolutionInfo()).Projects.Single();
+        var expectedPath = Path.Combine(compilerCallData.OutputDirectory!, compilerCallData.AssemblyFileName);
+
+        Assert.Equal(expectedPath, project.OutputFilePath);
+        Assert.True(Path.IsPathRooted(project.OutputFilePath));
+        Assert.True(File.Exists(project.OutputFilePath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MultiTargetProjectReferenceMapsToMatchingTargetFramework(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ConsoleWithMultiTargetReference.Value, useBinaryLog);
+        var reader = SolutionReader.Create(filePath, BasicAnalyzerKind.None);
+        ReaderList.Add(reader);
+        var firstSolutionInfo = reader.ReadSolutionInfo();
+        var secondSolutionInfo = reader.ReadSolutionInfo();
+        Assert.Equal(
+            firstSolutionInfo.Projects.Select(project => (project.FilePath, project.Id)),
+            secondSolutionInfo.Projects.Select(project => (project.FilePath, project.Id)));
+
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.AddSolution(firstSolutionInfo);
+        var appProject = solution.Projects.Single(
+            project => Path.GetFileName(project.FilePath) == "console-with-reference.csproj");
+        var referencedProject = solution.GetProject(Assert.Single(appProject.ProjectReferences).ProjectId);
+        var utilProjects = solution.Projects
+            .Where(project => project.FilePath!.EndsWith("util.csproj", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var targetFrameworkSymbol = TestUtil.TestTargetFramework
+            .Replace('.', '_')
+            .Replace('-', '_')
+            .ToUpperInvariant();
+        var matchingProject = utilProjects.Single(
+            project => ((CSharpParseOptions)project.ParseOptions!).PreprocessorSymbolNames.Contains(targetFrameworkSymbol));
+        var otherProject = utilProjects.Single(project => project.Id != matchingProject.Id);
+
+        Assert.Equal(2, utilProjects.Count);
+        Assert.Equal(matchingProject.Id, referencedProject!.Id);
+        Assert.NotEqual(otherProject.Id, referencedProject.Id);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PredicateDoesNotInventUncompiledTargetFrameworkVariants(bool useBinaryLog)
+    {
+        var filePath = GetLogFilePath(Fixture.ClassLibMulti.Value, useBinaryLog);
+        var reader = SolutionReader.Create(
+            filePath,
+            BasicAnalyzerKind.None,
+            predicate: compilerCall => compilerCall.TargetFramework == TestUtil.TestTargetFramework);
+        ReaderList.Add(reader);
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddSolution(reader.ReadSolutionInfo()).Projects.Single();
+
+        Assert.Equal(1, reader.ProjectCount);
+        Assert.Equal($"classlibmulti ({TestUtil.TestTargetFramework})", project.Name);
+    }
+
 }

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -270,7 +270,7 @@ public sealed class SolutionReaderTests : TestBase
         var compilerCallData = reader.Reader.ReadCompilerCallData(compilerCall);
         using var workspace = new AdhocWorkspace();
         var project = workspace.AddSolution(reader.ReadSolutionInfo()).Projects.Single();
-        var expectedPath = Path.Combine(compilerCallData.OutputDirectory!, compilerCallData.AssemblyFileName);
+        var expectedPath = Path.Combine(compilerCallData.OutputDirectory!, compilerCallData.OutputFileName);
 
         Assert.Equal(expectedPath, project.OutputFilePath);
         Assert.True(Path.IsPathRooted(project.OutputFilePath));

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -142,10 +142,9 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
     {
         var args = ReadCommandLineArguments(compilerCall);
         var assemblyFileName = RoslynUtil.GetAssemblyFileName(args);
-        var compilationName = Path.GetFileNameWithoutExtension(assemblyFileName);
         var data = new CompilerCallData(
             compilerCall,
-            compilationName,
+            assemblyFileName,
             args.OutputDirectory,
             args.ParseOptions,
             args.CompilationOptions,
@@ -427,7 +426,7 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
         var list = new List<SourceTextData>(args.SourceFiles.Length + args.AnalyzerConfigPaths.Length + args.AdditionalFiles.Length);
         list.AddRange(args.SourceFiles.Select(x => new SourceTextData(this, x.Path, args.ChecksumAlgorithm, SourceTextKind.SourceCode)));
         list.AddRange(args.AnalyzerConfigPaths.Select(x => new SourceTextData(this, x, args.ChecksumAlgorithm, SourceTextKind.AnalyzerConfig)));
-        list.AddRange(args.AdditionalFiles.Select(x => new SourceTextData(this, x.Path, args.ChecksumAlgorithm, SourceTextKind.AnalyzerConfig)));
+        list.AddRange(args.AdditionalFiles.Select(x => new SourceTextData(this, x.Path, args.ChecksumAlgorithm, SourceTextKind.AdditionalText)));
         return list;
     }
 

--- a/src/Basic.CompilerLog.Util/BinaryLogReader.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogReader.cs
@@ -141,10 +141,12 @@ public sealed class BinaryLogReader : ICompilerCallReader, IBasicAnalyzerHostDat
     private (CompilerCallData CompilerCallData, CommandLineArguments Arguments) ReadCompilerCallDataCore(CompilerCall compilerCall)
     {
         var args = ReadCommandLineArguments(compilerCall);
-        var assemblyFileName = RoslynUtil.GetAssemblyFileName(args);
+        var outputFileName = RoslynUtil.GetAssemblyFileName(args);
+        var assemblyFileName = Path.GetFileNameWithoutExtension(outputFileName);
         var data = new CompilerCallData(
             compilerCall,
             assemblyFileName,
+            outputFileName,
             args.OutputDirectory,
             args.ParseOptions,
             args.CompilationOptions,

--- a/src/Basic.CompilerLog.Util/CompilerCallData.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCallData.cs
@@ -13,6 +13,21 @@ public sealed class CompilerCallData(
     CompilationOptions compilationOptions,
     EmitOptions emitOptions)
 {
+    internal string OutputFileName { get; private set; } = assemblyFileName;
+
+    internal CompilerCallData(
+        CompilerCall compilerCall,
+        string assemblyFileName,
+        string outputFileName,
+        string? outputDirectory,
+        ParseOptions parseOptions,
+        CompilationOptions compilationOptions,
+        EmitOptions emitOptions)
+        : this(compilerCall, assemblyFileName, outputDirectory, parseOptions, compilationOptions, emitOptions)
+    {
+        OutputFileName = outputFileName;
+    }
+
     public CompilerCall CompilerCall { get; } = compilerCall;
     public string AssemblyFileName { get; } = assemblyFileName;
     public string? OutputDirectory { get; } = outputDirectory;

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -208,7 +208,7 @@ public sealed class CompilerLogReader : ICompilerCallReader, IBasicAnalyzerHostD
             pack.TargetFramework,
             pack.IsCSharp,
             NormalizeAndMapPath(pack.CompilerFilePath, PathMapKind.CompilerExecutableFile),
-            new CompilerCallState(this, index));
+            ownerState: new CompilerCallState(this, index));
     }
 
     public CompilerCallData ReadCompilerCallData(CompilerCall compilerCall)

--- a/src/Basic.CompilerLog.Util/Extensions.cs
+++ b/src/Basic.CompilerLog.Util/Extensions.cs
@@ -122,6 +122,24 @@ public static class Extensions
         return mdRef;
     }
 
+    public static HashSet<string> GetMultiTargetedProjectFilePaths(
+        this ICompilerCallReader compilerCallReader,
+        Func<CompilerCall, bool>? predicate = null)
+    {
+        var projectFilePaths = new HashSet<string>(PathUtil.Comparer);
+        var multiTargetedProjectFilePaths = new HashSet<string>(PathUtil.Comparer);
+        foreach (var compilerCall in compilerCallReader.ReadAllCompilerCalls(predicate))
+        {
+            if (compilerCall.Kind == CompilerCallKind.Regular &&
+                !projectFilePaths.Add(compilerCall.ProjectFilePath))
+            {
+                multiTargetedProjectFilePaths.Add(compilerCall.ProjectFilePath);
+            }
+        }
+
+        return multiTargetedProjectFilePaths;
+    }
+
     public static (List<string> Analyzers, List<string> Generators) ReadAnalyzerFullTypeNames(this ICompilerCallReader compilerCallReader, AnalyzerData analyzerData, bool? isCSharp = null)
     {
         var languageName = isCSharp switch

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -27,7 +27,6 @@ internal sealed class BasicAnalyzerHostInMemory : BasicAnalyzerHost
         var name = $"{nameof(BasicAnalyzerHostInMemory)} - {Guid.NewGuid().ToString("N")}";
         Loader = new InMemoryLoader(name, provider, analyzers);
     }
-
 #if NET
 
     /// <summary>
@@ -361,4 +360,3 @@ file sealed class BasicAnalyzerReference : AnalyzerReference, IBasicAnalyzerRefe
     [ExcludeFromCodeCoverage]
     public override string ToString() => $"In Memory {AssemblyName}";
 }
-

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostOnDisk.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostOnDisk.cs
@@ -260,4 +260,3 @@ internal sealed class OnDiskLoader : IDisposable
 }
 
 #endif
-

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -14,6 +14,7 @@ namespace Basic.CompilerLog.Util;
 public sealed class SolutionReader : IDisposable
 {
     private readonly SortedDictionary<int, (CompilerCall CompilerCall, ProjectId ProjectId)> _indexToProjectDataMap;
+    private readonly HashSet<string> _multiTargetProjectPaths;
 
     internal ICompilerCallReader Reader { get; }
     internal VersionStamp VersionStamp { get; }
@@ -29,6 +30,7 @@ public sealed class SolutionReader : IDisposable
         predicate ??= static c => c.Kind == CompilerCallKind.Regular;
         var map = new SortedDictionary<int, (CompilerCall, ProjectId)>();
         var compilerCalls = reader.ReadAllCompilerCalls();
+        _multiTargetProjectPaths = reader.GetMultiTargetedProjectFilePaths();
         for (int i = 0; i < compilerCalls.Count; i++)
         {
             var call = reader.ReadCompilerCall(i);
@@ -83,23 +85,32 @@ public sealed class SolutionReader : IDisposable
                 _ => throw new InvalidOperationException(),
             };
 
-            var fileName = sourceTextData.FilePath;
+            var filePath = sourceTextData.FilePath;
+            var fileName = Path.GetFileName(filePath);
             var documentId = DocumentId.CreateNewId(projectId, debugName: fileName);
             list.Add(DocumentInfo.Create(
                 documentId,
                 fileName,
+                folders: GetFolders(compilerCall.ProjectDirectory, filePath),
                 loader: new CompilerLogTextLoader(Reader, VersionStamp, sourceTextData),
-                filePath: sourceTextData.FilePath));
+                filePath: filePath));
         }
 
         var refTuple = ReadReferences();
         var compilerCallData = Reader.ReadCompilerCallData(compilerCall);
         var basicAnalyzeHost = Reader.CreateBasicAnalyzerHost(compilerCall);
+        var projectName = Path.GetFileNameWithoutExtension(compilerCall.ProjectFileName);
+        if (compilerCall.TargetFramework is not null &&
+            _multiTargetProjectPaths.Contains(compilerCall.ProjectFilePath))
+        {
+            projectName = $"{projectName} ({compilerCall.TargetFramework})";
+        }
+
         var projectInfo = ProjectInfo.Create(
             projectId,
             VersionStamp,
-            name: compilerCall.ProjectFileName,
-            assemblyName: compilerCallData.AssemblyFileName,
+            name: projectName,
+            assemblyName: Path.GetFileNameWithoutExtension(compilerCallData.AssemblyFileName),
             language: compilerCall.IsCSharp ? LanguageNames.CSharp : LanguageNames.VisualBasic,
             filePath: compilerCall.ProjectFilePath,
             outputFilePath: Path.Combine(compilerCallData.OutputDirectory ?? "", compilerCallData.AssemblyFileName),
@@ -136,10 +147,10 @@ public sealed class SolutionReader : IDisposable
                     continue;
                 }
 
-                if (Reader.TryGetCompilerCallIndex(referenceData.Mvid, out var refCompilerCallIndex))
+                if (Reader.TryGetCompilerCallIndex(referenceData.Mvid, out var refCompilerCallIndex) &&
+                    _indexToProjectDataMap.TryGetValue(refCompilerCallIndex, out var refProjectData))
                 {
-                    var refProjectId = _indexToProjectDataMap[refCompilerCallIndex].ProjectId;
-                    projectReferences.Add(new ProjectReference(refProjectId, referenceData.Aliases, referenceData.EmbedInteropTypes));
+                    projectReferences.Add(new ProjectReference(refProjectData.ProjectId, referenceData.Aliases, referenceData.EmbedInteropTypes));
                 }
                 else
                 {
@@ -149,6 +160,22 @@ public sealed class SolutionReader : IDisposable
             }
 
             return (projectReferences, metadataReferences);
+        }
+
+        static ImmutableArray<string> GetFolders(string projectDirectory, string filePath)
+        {
+            var relativePath = Path.GetRelativePath(projectDirectory, filePath);
+            if (Path.IsPathRooted(relativePath) ||
+                relativePath == ".." ||
+                relativePath.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                return [];
+            }
+
+            var directory = Path.GetDirectoryName(relativePath);
+            return string.IsNullOrEmpty(directory)
+                ? []
+                : directory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToImmutableArray();
         }
     }
 }

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -113,7 +113,7 @@ public sealed class SolutionReader : IDisposable
             assemblyName: Path.GetFileNameWithoutExtension(compilerCallData.AssemblyFileName),
             language: compilerCall.IsCSharp ? LanguageNames.CSharp : LanguageNames.VisualBasic,
             filePath: compilerCall.ProjectFilePath,
-            outputFilePath: Path.Combine(compilerCallData.OutputDirectory ?? "", compilerCallData.AssemblyFileName),
+            outputFilePath: Path.Combine(compilerCallData.OutputDirectory ?? "", compilerCallData.OutputFileName),
             compilationOptions: compilerCallData.CompilationOptions,
             parseOptions: compilerCallData.ParseOptions,
             documents,

--- a/src/Basic.CompilerLog.WorkspaceComparer/Basic.CompilerLog.WorkspaceComparer.csproj
+++ b/src/Basic.CompilerLog.WorkspaceComparer/Basic.CompilerLog.WorkspaceComparer.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\Basic.CompilerLog.Util\Basic.CompilerLog.Util.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Basic.CompilerLog.WorkspaceComparer/Program.cs
+++ b/src/Basic.CompilerLog.WorkspaceComparer/Program.cs
@@ -1,0 +1,53 @@
+using Basic.CompilerLog.Util;
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using Basic.CompilerLog.WorkspaceComparer;
+
+if (args.Length != 2)
+{
+    Console.Error.WriteLine("Usage: workspace-compare <project-or-solution> <compiler-log>");
+    return 1;
+}
+
+var buildPath = Path.GetFullPath(args[0]);
+var compilerLogPath = Path.GetFullPath(args[1]);
+if (!File.Exists(buildPath))
+{
+    Console.Error.WriteLine($"Project or solution does not exist: {buildPath}");
+    return 1;
+}
+
+if (!File.Exists(compilerLogPath))
+{
+    Console.Error.WriteLine($"Compiler log does not exist: {compilerLogPath}");
+    return 1;
+}
+
+MSBuildLocator.RegisterDefaults();
+using var msbuildWorkspace = MSBuildWorkspace.Create();
+msbuildWorkspace.RegisterWorkspaceFailedHandler(e => Console.Error.WriteLine($"MSBuildWorkspace: {e.Diagnostic}"));
+
+Solution expected;
+var buildExtension = Path.GetExtension(buildPath);
+if (string.Equals(buildExtension, ".sln", StringComparison.OrdinalIgnoreCase) ||
+    string.Equals(buildExtension, ".slnx", StringComparison.OrdinalIgnoreCase))
+{
+    expected = await msbuildWorkspace.OpenSolutionAsync(buildPath);
+}
+else
+{
+    expected = (await msbuildWorkspace.OpenProjectAsync(buildPath)).Solution;
+}
+
+using var solutionReader = SolutionReader.Create(compilerLogPath);
+using var adhocWorkspace = new AdhocWorkspace();
+var actual = adhocWorkspace.AddSolution(solutionReader.ReadSolutionInfo());
+var differences = WorkspaceComparer.Compare(expected, actual);
+foreach (var difference in differences)
+{
+    Console.WriteLine(difference);
+}
+
+Console.Error.WriteLine($"{differences.Length} difference(s)");
+return 0;

--- a/src/Basic.CompilerLog.WorkspaceComparer/WorkspaceComparer.cs
+++ b/src/Basic.CompilerLog.WorkspaceComparer/WorkspaceComparer.cs
@@ -1,0 +1,490 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
+using System.Collections.Immutable;
+
+namespace Basic.CompilerLog.WorkspaceComparer;
+
+/// <summary>
+/// Describes a difference between two Roslyn solutions.
+/// </summary>
+internal sealed class WorkspaceDifference
+{
+    public string Path { get; }
+    public string? Expected { get; }
+    public string? Actual { get; }
+
+    public WorkspaceDifference(string path, string? expected, string? actual)
+    {
+        Path = path;
+        Expected = expected;
+        Actual = actual;
+    }
+
+    public override string ToString() =>
+        $"{Path}: expected {Format(Expected)}, actual {Format(Actual)}";
+
+    private static string Format(string? value) => value is null ? "<missing>" : $"\"{value}\"";
+}
+
+/// <summary>
+/// Compares the observable structure of two Roslyn solutions.
+/// </summary>
+internal static class WorkspaceComparer
+{
+    private static StringComparer PathComparer { get; } =
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    public static ImmutableArray<WorkspaceDifference> Compare(Solution expected, Solution actual)
+    {
+        var builder = ImmutableArray.CreateBuilder<WorkspaceDifference>();
+        CompareValue(builder, "Solution.ProjectCount", expected.ProjectIds.Count, actual.ProjectIds.Count);
+
+        var expectedProjects = GroupProjects(expected.Projects);
+        var actualProjects = GroupProjects(actual.Projects);
+        foreach (var filePath in expectedProjects.Keys.Union(actualProjects.Keys, PathComparer).OrderBy(x => x, PathComparer))
+        {
+            expectedProjects.TryGetValue(filePath, out var expectedGroup);
+            actualProjects.TryGetValue(filePath, out var actualGroup);
+            expectedGroup ??= [];
+            actualGroup ??= [];
+
+            var pairs = PairProjects(expectedGroup, actualGroup);
+            foreach (var pair in pairs)
+            {
+                var projectPath = GetProjectPath(filePath, pair.Expected ?? pair.Actual!);
+                if (pair.Expected is null)
+                {
+                    builder.Add(new(projectPath, expected: null, DescribeProject(pair.Actual!)));
+                }
+                else if (pair.Actual is null)
+                {
+                    builder.Add(new(projectPath, DescribeProject(pair.Expected), actual: null));
+                }
+                else
+                {
+                    CompareProject(builder, projectPath, pair.Expected, pair.Actual);
+                }
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static Dictionary<string, List<Project>> GroupProjects(IEnumerable<Project> projects)
+    {
+        var map = new Dictionary<string, List<Project>>(PathComparer);
+        foreach (var project in projects)
+        {
+            var key = project.FilePath ?? $"<no file path>:{project.Name}:{project.Language}";
+            if (!map.TryGetValue(key, out var list))
+            {
+                list = [];
+                map.Add(key, list);
+            }
+
+            list.Add(project);
+        }
+
+        return map;
+    }
+
+    private static List<(Project? Expected, Project? Actual)> PairProjects(List<Project> expected, List<Project> actual)
+    {
+        var result = new List<(Project?, Project?)>();
+        var unmatchedActual = new List<Project>(actual);
+        foreach (var expectedProject in expected.OrderBy(GetProjectSortKey, StringComparer.Ordinal))
+        {
+            var index = -1;
+            var expectedTargetFramework = GetTargetFrameworkMoniker(expectedProject);
+            if (expectedProject.OutputFilePath is { } expectedOutputFilePath &&
+                expected.Count(project => PathComparer.Equals(expectedOutputFilePath, project.OutputFilePath)) == 1 &&
+                actual.Count(project => PathComparer.Equals(expectedOutputFilePath, project.OutputFilePath)) == 1)
+            {
+                index = unmatchedActual.FindIndex(actualProject =>
+                    PathComparer.Equals(expectedOutputFilePath, actualProject.OutputFilePath));
+            }
+
+            if (index < 0 && expectedTargetFramework is not null)
+            {
+                index = unmatchedActual.FindIndex(actualProject =>
+                    string.Equals(expectedTargetFramework, GetTargetFrameworkMoniker(actualProject), StringComparison.Ordinal));
+            }
+
+            if (index < 0 &&
+                unmatchedActual.Count > 0 &&
+                (expectedTargetFramework is null || unmatchedActual.All(project => GetTargetFrameworkMoniker(project) is null)))
+            {
+                index = 0;
+            }
+
+            if (index < 0)
+            {
+                result.Add((expectedProject, null));
+            }
+            else
+            {
+                result.Add((expectedProject, unmatchedActual[index]));
+                unmatchedActual.RemoveAt(index);
+            }
+        }
+
+        result.AddRange(unmatchedActual
+            .OrderBy(GetProjectSortKey, StringComparer.Ordinal)
+            .Select(static project => ((Project?)null, (Project?)project)));
+        return result;
+    }
+
+    private static void CompareProject(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string path,
+        Project expected,
+        Project actual)
+    {
+        CompareValue(builder, $"{path}.Name", expected.Name, actual.Name);
+        CompareValue(builder, $"{path}.AssemblyName", expected.AssemblyName, actual.AssemblyName);
+        CompareValue(builder, $"{path}.Language", expected.Language, actual.Language);
+        CompareValue(builder, $"{path}.FilePath", expected.FilePath, actual.FilePath);
+        CompareValue(builder, $"{path}.OutputFilePath", expected.OutputFilePath, actual.OutputFilePath);
+
+        CompareDocuments(builder, path, "Documents", expected.Documents, actual.Documents);
+        CompareDocuments(builder, path, "AdditionalDocuments", expected.AdditionalDocuments, actual.AdditionalDocuments);
+        CompareDocuments(builder, path, "AnalyzerConfigDocuments", expected.AnalyzerConfigDocuments, actual.AnalyzerConfigDocuments);
+        CompareProjectReferences(builder, path, expected, actual);
+        CompareMetadataReferences(builder, path, expected.MetadataReferences, actual.MetadataReferences);
+        CompareAnalyzerReferences(builder, path, expected.AnalyzerReferences, actual.AnalyzerReferences);
+        CompareCompilationOptions(builder, path, expected.CompilationOptions, actual.CompilationOptions);
+        CompareParseOptions(builder, path, expected.ParseOptions, actual.ParseOptions);
+    }
+
+    private static void CompareDocuments(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string projectPath,
+        string collectionName,
+        IEnumerable<TextDocument> expected,
+        IEnumerable<TextDocument> actual)
+    {
+        var expectedDocuments = GroupByPath(expected);
+        var actualDocuments = GroupByPath(actual);
+        CompareValue(builder, $"{projectPath}.{collectionName}.Count", expectedDocuments.Sum(x => x.Value.Count), actualDocuments.Sum(x => x.Value.Count));
+
+        foreach (var filePath in expectedDocuments.Keys.Union(actualDocuments.Keys, PathComparer).OrderBy(x => x, PathComparer))
+        {
+            expectedDocuments.TryGetValue(filePath, out var expectedGroup);
+            actualDocuments.TryGetValue(filePath, out var actualGroup);
+            expectedGroup ??= [];
+            actualGroup ??= [];
+            var count = Math.Max(expectedGroup.Count, actualGroup.Count);
+            for (var i = 0; i < count; i++)
+            {
+                var expectedDocument = i < expectedGroup.Count ? expectedGroup[i] : null;
+                var actualDocument = i < actualGroup.Count ? actualGroup[i] : null;
+                var path = $"{projectPath}.{collectionName}[{filePath}]";
+                if (expectedDocument is null)
+                {
+                    builder.Add(new(path, expected: null, DescribeDocument(actualDocument!)));
+                    continue;
+                }
+
+                if (actualDocument is null)
+                {
+                    builder.Add(new(path, DescribeDocument(expectedDocument), actual: null));
+                    continue;
+                }
+
+                CompareValue(builder, $"{path}.Name", expectedDocument.Name, actualDocument.Name);
+                CompareValue(builder, $"{path}.FilePath", expectedDocument.FilePath, actualDocument.FilePath);
+                CompareValue(builder, $"{path}.Folders", string.Join("/", expectedDocument.Folders), string.Join("/", actualDocument.Folders));
+                if (expectedDocument is Document expectedSource && actualDocument is Document actualSource)
+                {
+                    CompareValue(builder, $"{path}.SourceCodeKind", expectedSource.SourceCodeKind, actualSource.SourceCodeKind);
+                }
+            }
+        }
+
+        static Dictionary<string, List<TextDocument>> GroupByPath(IEnumerable<TextDocument> documents)
+        {
+            var map = new Dictionary<string, List<TextDocument>>(PathComparer);
+            foreach (var document in documents)
+            {
+                var key = document.FilePath ?? $"<no file path>:{document.Name}";
+                if (!map.TryGetValue(key, out var list))
+                {
+                    list = [];
+                    map.Add(key, list);
+                }
+
+                list.Add(document);
+            }
+
+            return map;
+        }
+    }
+
+    private static void CompareProjectReferences(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string projectPath,
+        Project expected,
+        Project actual)
+    {
+        var expectedReferences = Group(expected);
+        var actualReferences = Group(actual);
+        CompareValue(builder, $"{projectPath}.ProjectReferences.Count", expected.ProjectReferences.Count(), actual.ProjectReferences.Count());
+
+        foreach (var key in expectedReferences.Keys.Union(actualReferences.Keys, PathComparer).OrderBy(x => x, PathComparer))
+        {
+            expectedReferences.TryGetValue(key, out var expectedGroup);
+            actualReferences.TryGetValue(key, out var actualGroup);
+            expectedGroup ??= [];
+            actualGroup ??= [];
+            var count = Math.Max(expectedGroup.Count, actualGroup.Count);
+            for (var i = 0; i < count; i++)
+            {
+                var expectedReference = i < expectedGroup.Count ? expectedGroup[i] : default;
+                var actualReference = i < actualGroup.Count ? actualGroup[i] : default;
+                var expectedTarget = expectedReference.Target is null ? null : DescribeProject(expectedReference.Target);
+                var actualTarget = actualReference.Target is null ? null : DescribeProject(actualReference.Target);
+                var path = $"{projectPath}.ProjectReferences[{key}{GetIndexSuffix(count, i)}]";
+                if (expectedReference.Reference is null || actualReference.Reference is null)
+                {
+                    builder.Add(new(path, expectedTarget, actualTarget));
+                    continue;
+                }
+
+                CompareValue(builder, $"{path}.Target", expectedTarget, actualTarget);
+                CompareValue(builder, $"{path}.Aliases", FormatAliases(expectedReference.Reference.Aliases), FormatAliases(actualReference.Reference.Aliases));
+                CompareValue(builder, $"{path}.EmbedInteropTypes", expectedReference.Reference.EmbedInteropTypes, actualReference.Reference.EmbedInteropTypes);
+            }
+        }
+
+        static Dictionary<string, List<(ProjectReference Reference, Project? Target)>> Group(Project project) =>
+            project.ProjectReferences
+                .Select(reference => (Reference: reference, Target: project.Solution.GetProject(reference.ProjectId)))
+                .GroupBy(static pair => GetProjectReferenceKey(pair.Target), PathComparer)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.OrderBy(pair => FormatAliases(pair.Reference.Aliases), StringComparer.Ordinal).ToList(),
+                    PathComparer);
+    }
+
+    private static void CompareMetadataReferences(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string projectPath,
+        IEnumerable<MetadataReference> expected,
+        IEnumerable<MetadataReference> actual)
+    {
+        var expectedReferences = expected.GroupBy(GetReferenceName, PathComparer).ToDictionary(x => x.Key, x => x.OrderBy(GetReferenceSortKey, PathComparer).ToList(), PathComparer);
+        var actualReferences = actual.GroupBy(GetReferenceName, PathComparer).ToDictionary(x => x.Key, x => x.OrderBy(GetReferenceSortKey, PathComparer).ToList(), PathComparer);
+        CompareValue(builder, $"{projectPath}.MetadataReferences.Count", expectedReferences.Sum(x => x.Value.Count), actualReferences.Sum(x => x.Value.Count));
+
+        foreach (var name in expectedReferences.Keys.Union(actualReferences.Keys, PathComparer).OrderBy(x => x, PathComparer))
+        {
+            expectedReferences.TryGetValue(name, out var expectedGroup);
+            actualReferences.TryGetValue(name, out var actualGroup);
+            expectedGroup ??= [];
+            actualGroup ??= [];
+            var count = Math.Max(expectedGroup.Count, actualGroup.Count);
+            for (var i = 0; i < count; i++)
+            {
+                var expectedReference = i < expectedGroup.Count ? expectedGroup[i] : null;
+                var actualReference = i < actualGroup.Count ? actualGroup[i] : null;
+                var path = $"{projectPath}.MetadataReferences[{name}{GetIndexSuffix(count, i)}]";
+                if (expectedReference is null || actualReference is null)
+                {
+                    builder.Add(new(path, expectedReference?.Display, actualReference?.Display));
+                    continue;
+                }
+
+                CompareValue(builder, $"{path}.Display", expectedReference.Display, actualReference.Display);
+                CompareValue(builder, $"{path}.Aliases", FormatAliases(expectedReference.Properties.Aliases), FormatAliases(actualReference.Properties.Aliases));
+                CompareValue(builder, $"{path}.EmbedInteropTypes", expectedReference.Properties.EmbedInteropTypes, actualReference.Properties.EmbedInteropTypes);
+                CompareValue(builder, $"{path}.Kind", expectedReference.Properties.Kind, actualReference.Properties.Kind);
+            }
+        }
+    }
+
+    private static void CompareAnalyzerReferences(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string projectPath,
+        IEnumerable<AnalyzerReference> expected,
+        IEnumerable<AnalyzerReference> actual)
+    {
+        var expectedReferences = expected.GroupBy(GetAnalyzerName, PathComparer).ToDictionary(x => x.Key, x => x.OrderBy(GetAnalyzerSortKey, PathComparer).ToList(), PathComparer);
+        var actualReferences = actual.GroupBy(GetAnalyzerName, PathComparer).ToDictionary(x => x.Key, x => x.OrderBy(GetAnalyzerSortKey, PathComparer).ToList(), PathComparer);
+        CompareValue(builder, $"{projectPath}.AnalyzerReferences.Count", expectedReferences.Sum(x => x.Value.Count), actualReferences.Sum(x => x.Value.Count));
+
+        foreach (var name in expectedReferences.Keys.Union(actualReferences.Keys, PathComparer).OrderBy(x => x, PathComparer))
+        {
+            expectedReferences.TryGetValue(name, out var expectedGroup);
+            actualReferences.TryGetValue(name, out var actualGroup);
+            expectedGroup ??= [];
+            actualGroup ??= [];
+            var count = Math.Max(expectedGroup.Count, actualGroup.Count);
+            for (var i = 0; i < count; i++)
+            {
+                var expectedReference = i < expectedGroup.Count ? expectedGroup[i] : null;
+                var actualReference = i < actualGroup.Count ? actualGroup[i] : null;
+                var path = $"{projectPath}.AnalyzerReferences[{name}{GetIndexSuffix(count, i)}]";
+                if (expectedReference is null || actualReference is null)
+                {
+                    builder.Add(new(path, expectedReference?.FullPath ?? expectedReference?.Display, actualReference?.FullPath ?? actualReference?.Display));
+                    continue;
+                }
+
+                CompareValue(builder, $"{path}.Display", expectedReference.Display, actualReference.Display);
+                CompareValue(builder, $"{path}.FullPath", expectedReference.FullPath, actualReference.FullPath);
+            }
+        }
+    }
+
+    private static void CompareCompilationOptions(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string projectPath,
+        CompilationOptions? expected,
+        CompilationOptions? actual)
+    {
+        var path = $"{projectPath}.CompilationOptions";
+        CompareValue(builder, $"{path}.Type", expected?.GetType().FullName, actual?.GetType().FullName);
+        if (expected is null || actual is null)
+        {
+            return;
+        }
+
+        CompareValue(builder, $"{path}.OutputKind", expected.OutputKind, actual.OutputKind);
+        CompareValue(builder, $"{path}.ModuleName", expected.ModuleName, actual.ModuleName);
+        CompareValue(builder, $"{path}.MainTypeName", expected.MainTypeName, actual.MainTypeName);
+        CompareValue(builder, $"{path}.ScriptClassName", expected.ScriptClassName, actual.ScriptClassName);
+        CompareValue(builder, $"{path}.OptimizationLevel", expected.OptimizationLevel, actual.OptimizationLevel);
+        CompareValue(builder, $"{path}.CheckOverflow", expected.CheckOverflow, actual.CheckOverflow);
+        CompareValue(builder, $"{path}.Platform", expected.Platform, actual.Platform);
+        CompareValue(builder, $"{path}.GeneralDiagnosticOption", expected.GeneralDiagnosticOption, actual.GeneralDiagnosticOption);
+        CompareValue(builder, $"{path}.WarningLevel", expected.WarningLevel, actual.WarningLevel);
+        CompareValue(builder, $"{path}.ConcurrentBuild", expected.ConcurrentBuild, actual.ConcurrentBuild);
+        CompareValue(builder, $"{path}.Deterministic", expected.Deterministic, actual.Deterministic);
+        CompareValue(builder, $"{path}.CryptoKeyFile", expected.CryptoKeyFile, actual.CryptoKeyFile);
+        CompareValue(builder, $"{path}.CryptoKeyContainer", expected.CryptoKeyContainer, actual.CryptoKeyContainer);
+        CompareValue(builder, $"{path}.DelaySign", expected.DelaySign, actual.DelaySign);
+        CompareValue(builder, $"{path}.PublicSign", expected.PublicSign, actual.PublicSign);
+        CompareValue(builder, $"{path}.MetadataImportOptions", expected.MetadataImportOptions, actual.MetadataImportOptions);
+        CompareValue(builder, $"{path}.SpecificDiagnosticOptions", FormatMap(expected.SpecificDiagnosticOptions), FormatMap(actual.SpecificDiagnosticOptions));
+
+        if (expected is CSharpCompilationOptions expectedCSharp && actual is CSharpCompilationOptions actualCSharp)
+        {
+            CompareValue(builder, $"{path}.AllowUnsafe", expectedCSharp.AllowUnsafe, actualCSharp.AllowUnsafe);
+            CompareValue(builder, $"{path}.NullableContextOptions", expectedCSharp.NullableContextOptions, actualCSharp.NullableContextOptions);
+            CompareValue(builder, $"{path}.Usings", string.Join(",", expectedCSharp.Usings), string.Join(",", actualCSharp.Usings));
+        }
+
+        if (expected is VisualBasicCompilationOptions expectedVisualBasic && actual is VisualBasicCompilationOptions actualVisualBasic)
+        {
+            CompareValue(builder, $"{path}.OptionExplicit", expectedVisualBasic.OptionExplicit, actualVisualBasic.OptionExplicit);
+            CompareValue(builder, $"{path}.OptionInfer", expectedVisualBasic.OptionInfer, actualVisualBasic.OptionInfer);
+            CompareValue(builder, $"{path}.OptionStrict", expectedVisualBasic.OptionStrict, actualVisualBasic.OptionStrict);
+            CompareValue(builder, $"{path}.OptionCompareText", expectedVisualBasic.OptionCompareText, actualVisualBasic.OptionCompareText);
+            CompareValue(builder, $"{path}.RootNamespace", expectedVisualBasic.RootNamespace, actualVisualBasic.RootNamespace);
+            CompareValue(builder, $"{path}.GlobalImports", string.Join(",", expectedVisualBasic.GlobalImports), string.Join(",", actualVisualBasic.GlobalImports));
+        }
+    }
+
+    private static void CompareParseOptions(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string projectPath,
+        ParseOptions? expected,
+        ParseOptions? actual)
+    {
+        var path = $"{projectPath}.ParseOptions";
+        CompareValue(builder, $"{path}.Type", expected?.GetType().FullName, actual?.GetType().FullName);
+        if (expected is null || actual is null)
+        {
+            return;
+        }
+
+        CompareValue(builder, $"{path}.Kind", expected.Kind, actual.Kind);
+        CompareValue(builder, $"{path}.DocumentationMode", expected.DocumentationMode, actual.DocumentationMode);
+        CompareValue(builder, $"{path}.Features", FormatMap(expected.Features), FormatMap(actual.Features));
+        if (expected is CSharpParseOptions expectedCSharp && actual is CSharpParseOptions actualCSharp)
+        {
+            CompareValue(builder, $"{path}.LanguageVersion", expectedCSharp.LanguageVersion, actualCSharp.LanguageVersion);
+            CompareValue(builder, $"{path}.PreprocessorSymbols", string.Join(",", expectedCSharp.PreprocessorSymbolNames.OrderBy(x => x, StringComparer.Ordinal)), string.Join(",", actualCSharp.PreprocessorSymbolNames.OrderBy(x => x, StringComparer.Ordinal)));
+        }
+
+        if (expected is VisualBasicParseOptions expectedVisualBasic && actual is VisualBasicParseOptions actualVisualBasic)
+        {
+            CompareValue(builder, $"{path}.LanguageVersion", expectedVisualBasic.LanguageVersion, actualVisualBasic.LanguageVersion);
+            CompareValue(builder, $"{path}.PreprocessorSymbols", FormatMap(expectedVisualBasic.PreprocessorSymbols), FormatMap(actualVisualBasic.PreprocessorSymbols));
+        }
+    }
+
+    private static void CompareValue<T>(
+        ImmutableArray<WorkspaceDifference>.Builder builder,
+        string path,
+        T expected,
+        T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            builder.Add(new(path, expected?.ToString(), actual?.ToString()));
+        }
+    }
+
+    private static string GetProjectPath(string filePath, Project project) =>
+        $"Projects[{filePath}|{project.OutputFilePath ?? project.Name}]";
+
+    private static string GetProjectSortKey(Project? project) =>
+        project is null ? "" : $"{project.FilePath}|{project.OutputFilePath}|{project.Name}|{project.Language}";
+
+    private static string GetProjectReferenceKey(Project? project) =>
+        project is null
+            ? "<unresolved>"
+            : $"{project.FilePath}|{GetTargetFrameworkMoniker(project) ?? project.OutputFilePath ?? project.Name}";
+
+    private static string? GetTargetFrameworkMoniker(Project project)
+    {
+        if (project.OutputFilePath is { } outputFilePath)
+        {
+            foreach (var part in outputFilePath
+                .Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
+                .AsEnumerable()
+                .Reverse())
+            {
+                if (part.StartsWith("net", StringComparison.OrdinalIgnoreCase) &&
+                    part.Skip(3).Any(char.IsDigit))
+                {
+                    return part;
+                }
+            }
+        }
+
+        var openParen = project.Name.LastIndexOf('(');
+        return openParen >= 0 && project.Name.EndsWith(")", StringComparison.Ordinal)
+            ? project.Name.Substring(openParen + 1, project.Name.Length - openParen - 2)
+            : null;
+    }
+
+    private static string DescribeProject(Project project) =>
+        $"{project.Name}|{project.Language}|{project.FilePath}|{project.OutputFilePath}";
+
+    private static string DescribeDocument(TextDocument document) =>
+        $"{document.Name}|{document.FilePath}|{string.Join("/", document.Folders)}";
+
+    private static string GetReferenceSortKey(MetadataReference reference) =>
+        $"{GetReferenceName(reference)}|{reference.Display}|{FormatAliases(reference.Properties.Aliases)}";
+
+    private static string GetReferenceName(MetadataReference reference) =>
+        Path.GetFileName(reference.Display) ?? reference.Display ?? "<no display>";
+
+    private static string GetAnalyzerSortKey(AnalyzerReference reference) =>
+        $"{GetAnalyzerName(reference)}|{reference.FullPath}|{reference.Display}";
+
+    private static string GetAnalyzerName(AnalyzerReference reference) =>
+        Path.GetFileNameWithoutExtension(reference.FullPath ?? reference.Display) ?? "<no display>";
+
+    private static string FormatAliases(ImmutableArray<string> aliases) =>
+        aliases.IsDefaultOrEmpty ? "" : string.Join(",", aliases.OrderBy(x => x, StringComparer.Ordinal));
+
+    private static string GetIndexSuffix(int count, int index) => count > 1 ? $"#{index}" : "";
+
+    private static string FormatMap<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> map) where TKey : notnull =>
+        string.Join(",", map.OrderBy(x => x.Key).Select(x => $"{x.Key}={x.Value}"));
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,6 +21,11 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(_RoslynVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(_RoslynVersion)" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="$(_RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.14.2075" />


### PR DESCRIPTION
## Summary

- add a development tool that compares `MSBuildWorkspace` output with workspaces reconstructed from compiler logs
- align project, assembly, document, folder, additional-file, and multi-target project-reference behavior with common workspace conventions
- centralize multi-targeted project detection as a public `ICompilerCallReader` extension
- add parity tests covering both binary and compiler logs

## Testing

- `dotnet build Basic.CompilerLog.slnx -warnaserror --no-restore`
- full net10.0 test suite: 1,064 passed, 6 skipped